### PR TITLE
Add helper method to improve global memory indexing

### DIFF
--- a/src/gpu/BoysFuncGPU.hpp
+++ b/src/gpu/BoysFuncGPU.hpp
@@ -29,11 +29,51 @@
 
 namespace gpu {  // gpu namespace
 
+template<typename TPtr>
+using CharPtr = std::conditional_t<std::is_const_v<std::remove_pointer_t<TPtr>>, const char*, char*>;
+
+template<typename ValueType, typename IndexType, std::enable_if_t<std::is_integral<IndexType>::value, bool> = true>
+static inline __device__ __attribute__((always_inline)) IndexType calculateOffset(IndexType index)
+{
+    __builtin_assume(index >= 0);
+    return index * static_cast<IndexType>(sizeof(ValueType));
+}
+
+template<typename PointerType, typename IndexType, std::enable_if_t<std::is_integral<IndexType>::value, bool> = true>
+static inline __device__ __attribute__((always_inline)) PointerType indexedAddress(PointerType address,
+                                                                                          IndexType idx)
+{
+    return reinterpret_cast<PointerType>(reinterpret_cast<CharPtr<decltype(address)>>(address)
+                                         + calculateOffset<std::remove_pointer_t<PointerType>>(idx));
+}
+
+template<typename ValueType>
+class AmdFastBuffer
+{
+private:
+    ValueType* buffer;
+
+public:
+    __device__ AmdFastBuffer(ValueType* buffer) : buffer(buffer) {}
+    template<typename IndexType, std::enable_if_t<std::is_integral<IndexType>::value && std::is_const_v<std::remove_pointer_t<ValueType>>, bool> = true>
+    inline __device__ __attribute__((always_inline)) const ValueType& operator[](IndexType idx) const
+    {
+        return *indexedAddress(buffer, idx);
+    }
+    template<typename IndexType, std::enable_if_t<std::is_integral<IndexType>::value && !std::is_const_v<std::remove_pointer_t<ValueType>>, bool> = true>
+    inline __device__ __attribute__((always_inline)) ValueType& operator[](IndexType idx)
+    {
+        return *indexedAddress(buffer, idx);
+    }
+};
+
 __device__ void
-computeBoysFunction(double* values, const double fa, const uint32_t N, const double* bf_table, const double* ft)
+computeBoysFunction(double* values_in, const double fa, const uint32_t N, const double* bf_table, const double* ft_in)
 {
     // Note: 847 = 121 * 7
-    const double* bf_data = bf_table + N * 847;
+    AmdFastBuffer<const double> bf_data{bf_table + N * 847};
+    AmdFastBuffer<const double> ft{ft_in};
+    AmdFastBuffer<double> values{values_in};
 
     uint32_t pnt = (fa > 1.0e5) ? 1000000 : static_cast<uint32_t>(10.0 * fa + 0.5);
 
@@ -55,7 +95,7 @@ computeBoysFunction(double* values, const double fa, const uint32_t N, const dou
 
         for (uint32_t j = 0; j < N; j++)
         {
-            values[N - j - 1] = ft[N - j - 1] * (f2a * values[N - j] + fx);
+            values[N - j - 1] = ft[N - j - 1] * (f2a * values[N - j]+ fx);
         }
     }
     else

--- a/src/gpu/EriExchange.hip
+++ b/src/gpu/EriExchange.hip
@@ -31,20 +31,20 @@ namespace gpu {  // gpu namespace
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
 computeExchangeFockSSSS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_ss,
-                        const uint32_t* pair_inds_k_for_K_ss,
+                        const uint32_t* pair_inds_i_for_K_ss_in,
+                        const uint32_t* pair_inds_k_for_K_ss_in,
                         const uint32_t  pair_inds_count_for_K_ss,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
                         const double    ss_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ss,
-                        const uint32_t* D_inds_K_ss,
-                        const uint32_t* pair_displs_K_ss,
-                        const uint32_t* pair_counts_K_ss,
-                        const double*   pair_data_K_ss,
+                        const double*   Q_K_ss_in,
+                        const uint32_t* D_inds_K_ss_in,
+                        const uint32_t* pair_displs_K_ss_in,
+                        const uint32_t* pair_counts_K_ss_in,
+                        const double*   pair_data_K_ss_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -60,6 +60,17 @@ computeExchangeFockSSSS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<const uint32_t>  pair_inds_i_for_K_ss{pair_inds_i_for_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_inds_k_for_K_ss{pair_inds_k_for_K_ss_in};
+    AmdFastBuffer<const double  >  s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t>  s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  >  mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  >  Q_K_ss{Q_K_ss_in};
+    AmdFastBuffer<const uint32_t>  D_inds_K_ss{D_inds_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_displs_K_ss{pair_displs_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_counts_K_ss{pair_counts_K_ss_in};
+    AmdFastBuffer<const double  >  pair_data_K_ss{pair_data_K_ss_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -236,29 +247,29 @@ computeExchangeFockSSSS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSSSP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_ss,
-                        const uint32_t* pair_inds_k_for_K_ss,
+computeExchangeFockSSSP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_ss_in,
+                        const uint32_t* pair_inds_k_for_K_ss_in,
                         const uint32_t  pair_inds_count_for_K_ss,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    sp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ss,
-                        const double*   Q_K_sp,
-                        const uint32_t* D_inds_K_ss,
-                        const uint32_t* D_inds_K_sp,
-                        const uint32_t* pair_displs_K_ss,
-                        const uint32_t* pair_displs_K_sp,
-                        const uint32_t* pair_counts_K_ss,
-                        const uint32_t* pair_counts_K_sp,
-                        const double*   pair_data_K_ss,
-                        const double*   pair_data_K_sp,
+                        const double*   Q_K_ss_in,
+                        const double*   Q_K_sp_in,
+                        const uint32_t* D_inds_K_ss_in,
+                        const uint32_t* D_inds_K_sp_in,
+                        const uint32_t* pair_displs_K_ss_in,
+                        const uint32_t* pair_displs_K_sp_in,
+                        const uint32_t* pair_counts_K_ss_in,
+                        const uint32_t* pair_counts_K_sp_in,
+                        const double*   pair_data_K_ss_in,
+                        const double*   pair_data_K_sp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -274,6 +285,25 @@ computeExchangeFockSSSP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        >  mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t>  pair_inds_i_for_K_ss{pair_inds_i_for_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_inds_k_for_K_ss{pair_inds_k_for_K_ss_in};
+    AmdFastBuffer<const double  >  s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t>  s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  >  p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t>  p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  >  mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  >  Q_K_ss{Q_K_ss_in};
+    AmdFastBuffer<const double  >  Q_K_sp{Q_K_sp_in};
+    AmdFastBuffer<const uint32_t>  D_inds_K_ss{D_inds_K_ss_in};
+    AmdFastBuffer<const uint32_t>  D_inds_K_sp{D_inds_K_sp_in};
+    AmdFastBuffer<const uint32_t>  pair_displs_K_ss{pair_displs_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_displs_K_sp{pair_displs_K_sp_in};
+    AmdFastBuffer<const uint32_t>  pair_counts_K_ss{pair_counts_K_ss_in};
+    AmdFastBuffer<const uint32_t>  pair_counts_K_sp{pair_counts_K_sp_in};
+    AmdFastBuffer<const double  >  pair_data_K_ss{pair_data_K_ss_in};
+    AmdFastBuffer<const double  >  pair_data_K_sp{pair_data_K_sp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -467,29 +497,29 @@ computeExchangeFockSSSP(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSPSS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_ss,
-                        const uint32_t* pair_inds_k_for_K_ss,
+computeExchangeFockSPSS(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_ss_in,
+                        const uint32_t* pair_inds_k_for_K_ss_in,
                         const uint32_t  pair_inds_count_for_K_ss,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    ps_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_sp,
-                        const double*   Q_K_ss,
-                        const uint32_t* D_inds_K_sp,
-                        const uint32_t* D_inds_K_ss,
-                        const uint32_t* pair_displs_K_sp,
-                        const uint32_t* pair_displs_K_ss,
-                        const uint32_t* pair_counts_K_sp,
-                        const uint32_t* pair_counts_K_ss,
-                        const double*   pair_data_K_sp,
-                        const double*   pair_data_K_ss,
+                        const double*   Q_K_sp_in,
+                        const double*   Q_K_ss_in,
+                        const uint32_t* D_inds_K_sp_in,
+                        const uint32_t* D_inds_K_ss_in,
+                        const uint32_t* pair_displs_K_sp_in,
+                        const uint32_t* pair_displs_K_ss_in,
+                        const uint32_t* pair_counts_K_sp_in,
+                        const uint32_t* pair_counts_K_ss_in,
+                        const double*   pair_data_K_sp_in,
+                        const double*   pair_data_K_ss_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -505,6 +535,25 @@ computeExchangeFockSPSS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_ss{pair_inds_i_for_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_ss{pair_inds_k_for_K_ss_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_sp{Q_K_sp_in};
+    AmdFastBuffer<const double  > Q_K_ss{Q_K_ss_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_sp{D_inds_K_sp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ss{D_inds_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_sp{pair_displs_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ss{pair_displs_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_sp{pair_counts_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ss{pair_counts_K_ss_in};
+    AmdFastBuffer<const double  > pair_data_K_sp{pair_data_K_sp_in};
+    AmdFastBuffer<const double  > pair_data_K_ss{pair_data_K_ss_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -698,24 +747,24 @@ computeExchangeFockSPSS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSPSP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_ss,
-                        const uint32_t* pair_inds_k_for_K_ss,
+computeExchangeFockSPSP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_ss_in,
+                        const uint32_t* pair_inds_k_for_K_ss_in,
                         const uint32_t  pair_inds_count_for_K_ss,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    pp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_sp,
-                        const uint32_t* D_inds_K_sp,
-                        const uint32_t* pair_displs_K_sp,
-                        const uint32_t* pair_counts_K_sp,
-                        const double*   pair_data_K_sp,
+                        const double*   Q_K_sp_in,
+                        const uint32_t* D_inds_K_sp_in,
+                        const uint32_t* pair_displs_K_sp_in,
+                        const uint32_t* pair_counts_K_sp_in,
+                        const double*   pair_data_K_sp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -732,6 +781,20 @@ computeExchangeFockSPSP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_ss{pair_inds_i_for_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_ss{pair_inds_k_for_K_ss_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_sp{Q_K_sp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_sp{D_inds_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_sp{pair_displs_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_sp{pair_counts_K_sp_in};
+    AmdFastBuffer<const double  > pair_data_K_sp{pair_data_K_sp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -950,29 +1013,29 @@ computeExchangeFockSPSP(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSSPS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_sp,
-                        const uint32_t* pair_inds_k_for_K_sp,
+computeExchangeFockSSPS(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_sp_in,
+                        const uint32_t* pair_inds_k_for_K_sp_in,
                         const uint32_t  pair_inds_count_for_K_sp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    ss_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ss,
-                        const double*   Q_K_ps,
-                        const uint32_t* D_inds_K_ss,
-                        const uint32_t* D_inds_K_ps,
-                        const uint32_t* pair_displs_K_ss,
-                        const uint32_t* pair_displs_K_ps,
-                        const uint32_t* pair_counts_K_ss,
-                        const uint32_t* pair_counts_K_ps,
-                        const double*   pair_data_K_ss,
-                        const double*   pair_data_K_ps,
+                        const double*   Q_K_ss_in,
+                        const double*   Q_K_ps_in,
+                        const uint32_t* D_inds_K_ss_in,
+                        const uint32_t* D_inds_K_ps_in,
+                        const uint32_t* pair_displs_K_ss_in,
+                        const uint32_t* pair_displs_K_ps_in,
+                        const uint32_t* pair_counts_K_ss_in,
+                        const uint32_t* pair_counts_K_ps_in,
+                        const double*   pair_data_K_ss_in,
+                        const double*   pair_data_K_ps_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -989,6 +1052,25 @@ computeExchangeFockSSPS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_sp{pair_inds_i_for_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_sp{pair_inds_k_for_K_sp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_ss{Q_K_ss_in};
+    AmdFastBuffer<const double  > Q_K_ps{Q_K_ps_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ss{D_inds_K_ss_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ps{D_inds_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ss{pair_displs_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ps{pair_displs_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ss{pair_counts_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ps{pair_counts_K_ps_in};
+    AmdFastBuffer<const double  > pair_data_K_ss{pair_data_K_ss_in};
+    AmdFastBuffer<const double  > pair_data_K_ps{pair_data_K_ps_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -1183,29 +1265,29 @@ computeExchangeFockSSPS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSSPP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_sp,
-                        const uint32_t* pair_inds_k_for_K_sp,
+computeExchangeFockSSPP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_sp_in,
+                        const uint32_t* pair_inds_k_for_K_sp_in,
                         const uint32_t  pair_inds_count_for_K_sp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    sp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ss,
-                        const double*   Q_K_pp,
-                        const uint32_t* D_inds_K_ss,
-                        const uint32_t* D_inds_K_pp,
-                        const uint32_t* pair_displs_K_ss,
-                        const uint32_t* pair_displs_K_pp,
-                        const uint32_t* pair_counts_K_ss,
-                        const uint32_t* pair_counts_K_pp,
-                        const double*   pair_data_K_ss,
-                        const double*   pair_data_K_pp,
+                        const double*   Q_K_ss_in,
+                        const double*   Q_K_pp_in,
+                        const uint32_t* D_inds_K_ss_in,
+                        const uint32_t* D_inds_K_pp_in,
+                        const uint32_t* pair_displs_K_ss_in,
+                        const uint32_t* pair_displs_K_pp_in,
+                        const uint32_t* pair_counts_K_ss_in,
+                        const uint32_t* pair_counts_K_pp_in,
+                        const double*   pair_data_K_ss_in,
+                        const double*   pair_data_K_pp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -1223,6 +1305,25 @@ computeExchangeFockSSPP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_sp{pair_inds_i_for_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_sp{pair_inds_k_for_K_sp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_ss{Q_K_ss_in};
+    AmdFastBuffer<const double  > Q_K_pp{Q_K_pp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ss{D_inds_K_ss_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_pp{D_inds_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ss{pair_displs_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_pp{pair_displs_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ss{pair_counts_K_ss_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_pp{pair_counts_K_pp_in};
+    AmdFastBuffer<const double  > pair_data_K_ss{pair_data_K_ss_in};
+    AmdFastBuffer<const double  > pair_data_K_pp{pair_data_K_pp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -1442,29 +1543,29 @@ computeExchangeFockSSPP(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSPPS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_sp,
-                        const uint32_t* pair_inds_k_for_K_sp,
+computeExchangeFockSPPS(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_sp_in,
+                        const uint32_t* pair_inds_k_for_K_sp_in,
                         const uint32_t  pair_inds_count_for_K_sp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    ps_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_sp,
-                        const double*   Q_K_ps,
-                        const uint32_t* D_inds_K_sp,
-                        const uint32_t* D_inds_K_ps,
-                        const uint32_t* pair_displs_K_sp,
-                        const uint32_t* pair_displs_K_ps,
-                        const uint32_t* pair_counts_K_sp,
-                        const uint32_t* pair_counts_K_ps,
-                        const double*   pair_data_K_sp,
-                        const double*   pair_data_K_ps,
+                        const double*   Q_K_sp_in,
+                        const double*   Q_K_ps_in,
+                        const uint32_t* D_inds_K_sp_in,
+                        const uint32_t* D_inds_K_ps_in,
+                        const uint32_t* pair_displs_K_sp_in,
+                        const uint32_t* pair_displs_K_ps_in,
+                        const uint32_t* pair_counts_K_sp_in,
+                        const uint32_t* pair_counts_K_ps_in,
+                        const double*   pair_data_K_sp_in,
+                        const double*   pair_data_K_ps_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -1482,6 +1583,25 @@ computeExchangeFockSPPS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_sp{pair_inds_i_for_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_sp{pair_inds_k_for_K_sp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_sp{Q_K_sp_in};
+    AmdFastBuffer<const double  > Q_K_ps{Q_K_ps_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_sp{D_inds_K_sp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ps{D_inds_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_sp{pair_displs_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ps{pair_displs_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_sp{pair_counts_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ps{pair_counts_K_ps_in};
+    AmdFastBuffer<const double  > pair_data_K_sp{pair_data_K_sp_in};
+    AmdFastBuffer<const double  > pair_data_K_ps{pair_data_K_ps_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -1702,29 +1822,29 @@ computeExchangeFockSPPS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockSPPP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_sp,
-                        const uint32_t* pair_inds_k_for_K_sp,
+computeExchangeFockSPPP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_sp_in,
+                        const uint32_t* pair_inds_k_for_K_sp_in,
                         const uint32_t  pair_inds_count_for_K_sp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    pp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_sp,
-                        const double*   Q_K_pp,
-                        const uint32_t* D_inds_K_sp,
-                        const uint32_t* D_inds_K_pp,
-                        const uint32_t* pair_displs_K_sp,
-                        const uint32_t* pair_displs_K_pp,
-                        const uint32_t* pair_counts_K_sp,
-                        const uint32_t* pair_counts_K_pp,
-                        const double*   pair_data_K_sp,
-                        const double*   pair_data_K_pp,
+                        const double*   Q_K_sp_in,
+                        const double*   Q_K_pp_in,
+                        const uint32_t* D_inds_K_sp_in,
+                        const uint32_t* D_inds_K_pp_in,
+                        const uint32_t* pair_displs_K_sp_in,
+                        const uint32_t* pair_displs_K_pp_in,
+                        const uint32_t* pair_counts_K_sp_in,
+                        const uint32_t* pair_counts_K_pp_in,
+                        const double*   pair_data_K_sp_in,
+                        const double*   pair_data_K_pp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -1742,6 +1862,25 @@ computeExchangeFockSPPP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_sp{pair_inds_i_for_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_sp{pair_inds_k_for_K_sp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_sp{Q_K_sp_in};
+    AmdFastBuffer<const double  > Q_K_pp{Q_K_pp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_sp{D_inds_K_sp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_pp{D_inds_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_sp{pair_displs_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_pp{pair_displs_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_sp{pair_counts_K_sp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_pp{pair_counts_K_pp_in};
+    AmdFastBuffer<const double  > pair_data_K_sp{pair_data_K_sp_in};
+    AmdFastBuffer<const double  > pair_data_K_pp{pair_data_K_pp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -1996,24 +2135,24 @@ computeExchangeFockSPPP(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockPSPS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_pp,
-                        const uint32_t* pair_inds_k_for_K_pp,
+computeExchangeFockPSPS(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_pp_in,
+                        const uint32_t* pair_inds_k_for_K_pp_in,
                         const uint32_t  pair_inds_count_for_K_pp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    ss_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ps,
-                        const uint32_t* D_inds_K_ps,
-                        const uint32_t* pair_displs_K_ps,
-                        const uint32_t* pair_counts_K_ps,
-                        const double*   pair_data_K_ps,
+                        const double*   Q_K_ps_in,
+                        const uint32_t* D_inds_K_ps_in,
+                        const uint32_t* pair_displs_K_ps_in,
+                        const uint32_t* pair_counts_K_ps_in,
+                        const double*   pair_data_K_ps_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -2031,6 +2170,20 @@ computeExchangeFockPSPS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_pp{pair_inds_i_for_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_pp{pair_inds_k_for_K_pp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_ps{Q_K_ps_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ps{D_inds_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ps{pair_displs_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ps{pair_counts_K_ps_in};
+    AmdFastBuffer<const double  > pair_data_K_ps{pair_data_K_ps_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -2251,29 +2404,29 @@ computeExchangeFockPSPS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockPSPP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_pp,
-                        const uint32_t* pair_inds_k_for_K_pp,
+computeExchangeFockPSPP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_pp_in,
+                        const uint32_t* pair_inds_k_for_K_pp_in,
                         const uint32_t  pair_inds_count_for_K_pp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    sp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_ps,
-                        const double*   Q_K_pp,
-                        const uint32_t* D_inds_K_ps,
-                        const uint32_t* D_inds_K_pp,
-                        const uint32_t* pair_displs_K_ps,
-                        const uint32_t* pair_displs_K_pp,
-                        const uint32_t* pair_counts_K_ps,
-                        const uint32_t* pair_counts_K_pp,
-                        const double*   pair_data_K_ps,
-                        const double*   pair_data_K_pp,
+                        const double*   Q_K_ps_in,
+                        const double*   Q_K_pp_in,
+                        const uint32_t* D_inds_K_ps_in,
+                        const uint32_t* D_inds_K_pp_in,
+                        const uint32_t* pair_displs_K_ps_in,
+                        const uint32_t* pair_displs_K_pp_in,
+                        const uint32_t* pair_counts_K_ps_in,
+                        const uint32_t* pair_counts_K_pp_in,
+                        const double*   pair_data_K_ps_in,
+                        const double*   pair_data_K_pp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -2291,6 +2444,25 @@ computeExchangeFockPSPP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_pp{pair_inds_i_for_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_pp{pair_inds_k_for_K_pp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_ps{Q_K_ps_in};
+    AmdFastBuffer<const double  > Q_K_pp{Q_K_pp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ps{D_inds_K_ps_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_pp{D_inds_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ps{pair_displs_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_pp{pair_displs_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ps{pair_counts_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_pp{pair_counts_K_pp_in};
+    AmdFastBuffer<const double  > pair_data_K_ps{pair_data_K_ps_in};
+    AmdFastBuffer<const double  > pair_data_K_pp{pair_data_K_pp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -2546,29 +2718,29 @@ computeExchangeFockPSPP(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockPPPS(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_pp,
-                        const uint32_t* pair_inds_k_for_K_pp,
+computeExchangeFockPPPS(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_pp_in,
+                        const uint32_t* pair_inds_k_for_K_pp_in,
                         const uint32_t  pair_inds_count_for_K_pp,
-                        const double*   s_prim_info,
-                        const uint32_t* s_prim_aoinds,
+                        const double*   s_prim_info_in,
+                        const uint32_t* s_prim_aoinds_in,
                         const uint32_t  s_prim_count,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    ps_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_pp,
-                        const double*   Q_K_ps,
-                        const uint32_t* D_inds_K_pp,
-                        const uint32_t* D_inds_K_ps,
-                        const uint32_t* pair_displs_K_pp,
-                        const uint32_t* pair_displs_K_ps,
-                        const uint32_t* pair_counts_K_pp,
-                        const uint32_t* pair_counts_K_ps,
-                        const double*   pair_data_K_pp,
-                        const double*   pair_data_K_ps,
+                        const double*   Q_K_pp_in,
+                        const double*   Q_K_ps_in,
+                        const uint32_t* D_inds_K_pp_in,
+                        const uint32_t* D_inds_K_ps_in,
+                        const uint32_t* pair_displs_K_pp_in,
+                        const uint32_t* pair_displs_K_ps_in,
+                        const uint32_t* pair_counts_K_pp_in,
+                        const uint32_t* pair_counts_K_ps_in,
+                        const double*   pair_data_K_pp_in,
+                        const double*   pair_data_K_ps_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -2586,6 +2758,25 @@ computeExchangeFockPPPS(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_pp{pair_inds_i_for_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_pp{pair_inds_k_for_K_pp_in};
+    AmdFastBuffer<const double  > s_prim_info{s_prim_info_in};
+    AmdFastBuffer<const uint32_t> s_prim_aoinds{s_prim_aoinds_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_pp{Q_K_pp_in};
+    AmdFastBuffer<const double  > Q_K_ps{Q_K_ps_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_pp{D_inds_K_pp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_ps{D_inds_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_pp{pair_displs_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_ps{pair_displs_K_ps_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_pp{pair_counts_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_ps{pair_counts_K_ps_in};
+    AmdFastBuffer<const double  > pair_data_K_pp{pair_data_K_pp_in};
+    AmdFastBuffer<const double  > pair_data_K_ps{pair_data_K_ps_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {
@@ -2842,21 +3033,21 @@ computeExchangeFockPPPS(double*         mat_K,
 }
 
 __global__ void __launch_bounds__(TILE_SIZE_K)
-computeExchangeFockPPPP(double*         mat_K,
-                        const uint32_t* pair_inds_i_for_K_pp,
-                        const uint32_t* pair_inds_k_for_K_pp,
+computeExchangeFockPPPP(double*         mat_K_in,
+                        const uint32_t* pair_inds_i_for_K_pp_in,
+                        const uint32_t* pair_inds_k_for_K_pp_in,
                         const uint32_t  pair_inds_count_for_K_pp,
-                        const double*   p_prim_info,
-                        const uint32_t* p_prim_aoinds,
+                        const double*   p_prim_info_in,
+                        const uint32_t* p_prim_aoinds_in,
                         const uint32_t  p_prim_count,
                         const double    pp_max_D,
-                        const double*   mat_D_full_AO,
+                        const double*   mat_D_full_AO_in,
                         const uint32_t  naos,
-                        const double*   Q_K_pp,
-                        const uint32_t* D_inds_K_pp,
-                        const uint32_t* pair_displs_K_pp,
-                        const uint32_t* pair_counts_K_pp,
-                        const double*   pair_data_K_pp,
+                        const double*   Q_K_pp_in,
+                        const uint32_t* D_inds_K_pp_in,
+                        const uint32_t* pair_displs_K_pp_in,
+                        const uint32_t* pair_counts_K_pp_in,
+                        const double*   pair_data_K_pp_in,
                         const double*   boys_func_table,
                         const double*   boys_func_ft,
                         const double    omega,
@@ -2874,6 +3065,18 @@ computeExchangeFockPPPP(double*         mat_K,
     const uint32_t ik = blockIdx.x;
 
     double K_ik = 0.0, d2 = 1.0;
+
+    AmdFastBuffer<double        > mat_K{mat_K_in};
+    AmdFastBuffer<const uint32_t> pair_inds_i_for_K_pp{pair_inds_i_for_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_inds_k_for_K_pp{pair_inds_k_for_K_pp_in};
+    AmdFastBuffer<const double  > p_prim_info{p_prim_info_in};
+    AmdFastBuffer<const uint32_t> p_prim_aoinds{p_prim_aoinds_in};
+    AmdFastBuffer<const double  > mat_D_full_AO{mat_D_full_AO_in};
+    AmdFastBuffer<const double  > Q_K_pp{Q_K_pp_in};
+    AmdFastBuffer<const uint32_t> D_inds_K_pp{D_inds_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_displs_K_pp{pair_displs_K_pp_in};
+    AmdFastBuffer<const uint32_t> pair_counts_K_pp{pair_counts_K_pp_in};
+    AmdFastBuffer<const double  > pair_data_K_pp{pair_data_K_pp_in};
 
     if ((threadIdx.y == 0) && (threadIdx.x == 0))
     {


### PR DESCRIPTION
Just using the default array subscript on global memory addresses can introduce additional offset calculations (see also https://github.com/llvm/llvm-project/issues/55314).

Added a helper method that manually calculates the offset and start using it in EriExchange and the BoysFuncGPU method.