### PR TITLE
Added multi-conformer support for Boltzmann-weighted RESP charges

### DIFF
--- a/src/pymodule/respchargesdriver.py
+++ b/src/pymodule/respchargesdriver.py
@@ -523,7 +523,8 @@ class RespChargesDriver:
                 scf_drv.filename = f'conformer_{ind + 1}'
                 
                 # Disable restart for multi-conformer calculations to avoid
-                # using previous conformer's checkpoint as initial guess
+                # using previous conformer's checkpoint as initial guess as this 
+                # lead to convergence issues
                 scf_drv.restart = False
                 
                 if self.scf_max_iter is not None:


### PR DESCRIPTION
These changes add support for computing Boltzmann-weighted RESP charges from multiple conformers.
This is useful, for example, to obtain ensemble-averaged RESP charges that can be used to re-parameterize a force field in a subsequent step.