### PR TITLE
Fix mmffgenerator water

### DIFF
--- a/src/pymodule/mmforcefieldgenerator.py
+++ b/src/pymodule/mmforcefieldgenerator.py
@@ -1151,11 +1151,10 @@ class MMForceFieldGenerator:
         atomtypeidentifier.identify_equivalences()
         self.equivalent_atoms = atomtypeidentifier.equivalent_atoms
         self.equivalent_charges = atomtypeidentifier.equivalent_charges
-
-        contains_water = molecule.contains_water_molecule()
+        
+        # Only apply MM water model when it is a isolated water molecule, not when it is a part of the system. 
         is_water = molecule.is_water_molecule()
-        use_water_model = ((water_model is not None) and
-                           (is_water or contains_water))
+        use_water_model = ((water_model is not None) and is_water)
         skip_resp = (not resp) or ((water_model is not None) and is_water)
 
         if skip_resp:

--- a/src/pymodule/waterparameters.py
+++ b/src/pymodule/waterparameters.py
@@ -69,7 +69,7 @@ def get_water_parameters():
                 'name': 'H',
                 'mass': 1.007825,
                 'charge': 0.4238,
-                'sigma': 1.0,
+                'sigma': 1.0000e-01,
                 'epsilon': 0.0,
                 'equivalent_atom': 'hw_00',
                 'comment': 'SPC/E water'
@@ -142,7 +142,7 @@ def get_water_parameters():
                 'name': 'H',
                 'mass': 1.007825,
                 'charge': 0.417,
-                'sigma': 1.0,
+                'sigma': 1.0000e-01,
                 'epsilon': 0.0,
                 'equivalent_atom': 'hw_00',
                 'comment': 'TIP-3P water'


### PR DESCRIPTION
This pull request refines how water models are applied in topology generation and corrects parameter values for water hydrogen atoms. The main changes ensure that the MM water model is only used for isolated water molecules and fix the `sigma` parameter for hydrogen atoms in two water models.

Water model application logic:

* In `mmforcefieldgenerator.py`, the MM water model is now applied only when the molecule is an isolated water molecule, not when it is part of a larger system. This prevents unintended application of water parameters to water molecules embedded within larger structures.

Water parameter corrections:

* In `waterparameters.py`, the `sigma` value for hydrogen atoms in both the SPC/E and TIP-3P water models has been corrected from `1.0` to `0.10000` to reflect accurate physical parameters. [[1]](diffhunk://#diff-8b8cbbb6469de3f84579294674eaebf6db696c3841f1844f53b1032c33aea40bL72-R72) [[2]](diffhunk://#diff-8b8cbbb6469de3f84579294674eaebf6db696c3841f1844f53b1032c33aea40bL145-R145)