### PR TITLE
Added show fct for RESP charges and dipole visualization

### DIFF
--- a/src/pymodule/respchargesdriver.py
+++ b/src/pymodule/respchargesdriver.py
@@ -721,7 +721,11 @@ class RespChargesDriver(EspChargesDriver):
             The dipole moment vector in atomic units (e·bohr).
         """
 
-        charges = np.asarray(charges)
+        charges = np.asarray(charges).ravel()
+        if charges.size != molecule.number_of_atoms():
+            raise ValueError(
+                f'Expected {molecule.number_of_atoms()} charges but got '
+                f'{charges.size}.')
         coords = molecule.get_coordinates_in_bohr()
         nuclear_charges = molecule.get_element_ids()
         origin = (np.sum(coords.T * nuclear_charges, axis=1) /
@@ -784,7 +788,7 @@ class RespChargesDriver(EspChargesDriver):
             dipole_moment = self.get_dipole_moment(molecule, charges)
         dipole_moment = np.asarray(dipole_moment)
 
-        # Diverging colormap centered at zero charge
+        # Colormap centered at zero charge (normalization spans [-charge_max, charge_max])
         if charge_max is None:
             charge_max = float(np.max(np.abs(charges)))
             if charge_max < 1e-6:
@@ -798,7 +802,12 @@ class RespChargesDriver(EspChargesDriver):
         norm = mcolors.TwoSlopeNorm(vmin=-charge_max,
                                     vcenter=0.0,
                                     vmax=charge_max)
-        colormap = colormaps[cmap]
+        try:
+            colormap = colormaps[cmap]
+        except KeyError:
+            raise ValueError(
+                f"'{cmap}' is not a valid colormap name. "
+                'See list(matplotlib.colormaps) for available options.')
 
         atom_colors = [
             mcolors.to_hex(colormap(norm(float(q))), keep_alpha=False)

--- a/src/pymodule/respchargesdriver.py
+++ b/src/pymodule/respchargesdriver.py
@@ -789,6 +789,12 @@ class RespChargesDriver(EspChargesDriver):
             charge_max = float(np.max(np.abs(charges)))
             if charge_max < 1e-6:
                 charge_max = 1.0
+        else:
+            charge_max = float(charge_max)
+            if charge_max <= 0.0:
+                raise ValueError(
+                    'charge_max must be a positive number when provided '
+                    'explicitly.')
         norm = mcolors.TwoSlopeNorm(vmin=-charge_max,
                                     vcenter=0.0,
                                     vmax=charge_max)

--- a/src/pymodule/respchargesdriver.py
+++ b/src/pymodule/respchargesdriver.py
@@ -704,3 +704,178 @@ class RespChargesDriver(EspChargesDriver):
         if self.strong_restraint != 0.001:
             return False
         return True
+
+    def get_dipole_moment(self, molecule, charges):
+        """
+        Computes the dipole moment from atom-centered charges.
+
+        The origin is the nuclear charge centroid so that the result is
+        independent of the choice of origin for neutral molecules.
+
+        :param molecule:
+            The molecule.
+        :param charges:
+            The atom-centered charges in atomic units.
+
+        :return:
+            The dipole moment vector in atomic units (e·bohr).
+        """
+
+        charges = np.asarray(charges)
+        coords = molecule.get_coordinates_in_bohr()
+        nuclear_charges = molecule.get_element_ids()
+        origin = (np.sum(coords.T * nuclear_charges, axis=1) /
+                  np.sum(nuclear_charges))
+        return np.sum((coords - origin).T * charges, axis=1)
+
+    def show(self,
+             molecule,
+             charges,
+             dipole_moment=None,
+             cmap='viridis',
+             charge_max=None,
+             width=500,
+             height=400,
+             show_colorbar=True):
+        """
+        Displays atoms colored by RESP charges with an optional dipole moment
+        arrow and colorbar.
+
+        The dipole moment arrow is automatically scaled so that it fits within
+        the molecular bounding sphere (80% of the radius from the nuclear
+        charge centroid to the farthest atom).
+
+        :param molecule:
+            The molecule.
+        :param charges:
+            The atom-centered RESP charges in atomic units.
+        :param dipole_moment:
+            The dipole moment vector in atomic units (e·bohr). If None, the
+            dipole moment is computed from the RESP charges.
+        :param cmap:
+            The matplotlib colormap name (default: 'viridis').
+        :param charge_max:
+            The charge value mapped to the extremes of the colormap. If None,
+            the maximum absolute charge is used.
+        :param width:
+            The viewer width in pixels.
+        :param height:
+            The viewer height in pixels.
+        :param show_colorbar:
+            If True, a matplotlib colorbar is displayed alongside the viewer.
+        """
+
+        if self.rank != mpi_master():
+            return
+
+        try:
+            import json
+            import py3Dmol
+            from matplotlib import colormaps
+            from matplotlib import colors as mcolors
+        except ImportError:
+            raise ImportError(
+                'py3Dmol and matplotlib are required for this functionality.')
+
+        charges = np.asarray(charges)
+
+        # Compute dipole moment from charges when not provided
+        if dipole_moment is None:
+            dipole_moment = self.get_dipole_moment(molecule, charges)
+        dipole_moment = np.asarray(dipole_moment)
+
+        # Diverging colormap centered at zero charge
+        if charge_max is None:
+            charge_max = float(np.max(np.abs(charges)))
+            if charge_max < 1e-6:
+                charge_max = 1.0
+        norm = mcolors.TwoSlopeNorm(vmin=-charge_max,
+                                    vcenter=0.0,
+                                    vmax=charge_max)
+        colormap = colormaps[cmap]
+
+        atom_colors = [
+            mcolors.to_hex(colormap(norm(float(q))), keep_alpha=False)
+            for q in charges
+        ]
+        atom_colors_js = json.dumps(atom_colors)
+
+        # Build py3Dmol viewer with per-atom charge coloring
+        view = py3Dmol.view(width=width, height=height)
+        view.addModel(molecule.get_xyz_string(), 'xyz')
+
+        view.startjs += f"""
+    var atom_colors = {atom_colors_js};
+
+    function chargeColor(atom) {{
+        var c = atom_colors[atom.index];
+        return c !== undefined ? c : '#B0B0B0';
+    }}
+    """
+
+        view.setViewStyle({'style': 'outline', 'width': 0.05})
+        view.setStyle({}, {
+            'stick': {
+                'radius': 0.25,
+                'colorfunc': 'chargeColor'
+            },
+            'sphere': {
+                'scale': 0.25,
+                'colorfunc': 'chargeColor'
+            },
+        })
+        # Replace the quoted function name string with the actual JS reference
+        view.startjs = view.startjs.replace('"chargeColor"', 'chargeColor')
+
+        # Dipole moment arrow — auto-scaled to fit within molecular bounds.
+        # The arrow length is capped at 80% of the molecular radius
+        # (max distance from the nuclear charge centroid to any atom).
+        nuclear_charges = molecule.get_element_ids()
+        coords_ang = molecule.get_coordinates_in_angstrom()
+        origin = (np.sum(coords_ang.T * nuclear_charges, axis=1) /
+                  np.sum(nuclear_charges))
+
+        mol_radius = float(np.max(np.linalg.norm(coords_ang - origin, axis=1)))
+        target_length = 0.8 * mol_radius  # Angstrom
+
+        # dipole_moment is in a.u. (e·bohr); convert to Angstrom for display
+        dip_ang = dipole_moment * bohr_in_angstrom()
+        dip_length = float(np.linalg.norm(dip_ang))
+        if dip_length > 1e-6:
+            scaled_dip = dip_ang * (target_length / dip_length)
+        else:
+            scaled_dip = dip_ang
+
+        view.addArrow({
+            'start': {
+                'x': float(origin[0]),
+                'y': float(origin[1]),
+                'z': float(origin[2])
+            },
+            'end': {
+                'x': float(origin[0] + scaled_dip[0]),
+                'y': float(origin[1] + scaled_dip[1]),
+                'z': float(origin[2] + scaled_dip[2])
+            },
+            'radius': 0.08,
+            'radiusRatio': 2.5,
+            'color': 'dimgray',
+        })
+
+        view.zoomTo()
+        view.show()
+
+        # Colorbar
+        if show_colorbar:
+            from matplotlib import pyplot as plt
+            from matplotlib.colorbar import ColorbarBase
+
+            fig, ax = plt.subplots(figsize=(0.6, 3.5))
+            cb = ColorbarBase(ax,
+                              cmap=colormap,
+                              norm=norm,
+                              orientation='vertical')
+            cb.set_label('Charge (a.u.)', rotation=90, labelpad=10)
+            cb.ax.tick_params(labelsize=9)
+            plt.tight_layout()
+            plt.show()

--- a/tests/test_resp_charges.py
+++ b/tests/test_resp_charges.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import numpy as np
 
 from veloxchem.veloxchemlib import mpi_master
+from veloxchem.molecule import Molecule
 from veloxchem.mpitask import MpiTask
 from veloxchem.scfrestdriver import ScfRestrictedDriver
 from veloxchem.respchargesdriver import RespChargesDriver
@@ -80,3 +81,32 @@ class TestRespCharges:
         chg_dict = {'number_layers': 1}
 
         self.run_resp(inpfile, ref_resp_charges, chg_dict, 'resp', ['C', 3.0])
+
+    def test_get_dipole_moment(self):
+
+        # H2 molecule: two H atoms separated by 1 bohr along the x-axis.
+        # Nuclear charges are both 1, so the nuclear charge centroid is at
+        # (0.5, 0, 0). With charges [+0.5, -0.5], the expected dipole is:
+        #   x: (0 - 0.5)*0.5 + (1 - 0.5)*(-0.5) = -0.25 - 0.25 = -0.5
+        #   y, z: 0
+
+        mol_str = 'H  0.0  0.0  0.0\nH  1.0  0.0  0.0'
+        molecule = Molecule.read_str(mol_str, units='au')
+
+        charges = np.array([0.5, -0.5])
+
+        chg_drv = RespChargesDriver()
+        dipole = chg_drv.get_dipole_moment(molecule, charges)
+
+        assert np.allclose(dipole, np.array([-0.5, 0.0, 0.0]), atol=1.0e-10)
+
+        # For a neutral charge set (sum of charges = 0), the dipole moment
+        # must be independent of the choice of origin (origin invariance).
+        # Shift the molecule by an arbitrary vector (5, 3, 2) bohr.
+
+        mol_str_shifted = 'H  5.0  3.0  2.0\nH  6.0  3.0  2.0'
+        molecule_shifted = Molecule.read_str(mol_str_shifted, units='au')
+
+        dipole_shifted = chg_drv.get_dipole_moment(molecule_shifted, charges)
+
+        assert np.allclose(dipole, dipole_shifted, atol=1.0e-10)


### PR DESCRIPTION
---

## PR Description

**Add `show()` and `get_dipole_moment()` to `RespChargesDriver`**

### Summary

Two new methods added to `RespChargesDriver` in `respchargesdriver.py`:

- **`get_dipole_moment(molecule, charges)`** — computes the dipole moment vector (a.u.) from RESP charges relative to the nuclear charge centroid.
- **`show(molecule, charges, ...)`** — 3D visualization of RESP charges with a dipole moment arrow.

### Features of `show()`

- Atoms are colored by charge using a diverging colormap centered at zero (`viridis` by default).
- A dipole moment arrow is drawn from the nuclear charge centroid, automatically scaled to 80% of the molecular radius so it always fits within the molecule.
- A matplotlib colorbar is shown alongside the viewer.
- The QM dipole moment from SCF results can optionally be passed instead.

### Usage

```python
resp_drv = vlx.RespChargesDriver()
resp_charges = resp_drv.compute(molecule, basis, scf_results)

# Default: viridis colormap, dipole from RESP charges
resp_drv.show(molecule, resp_charges)

# Use QM dipole moment instead
resp_drv.show(molecule, resp_charges, dipole_moment=scf_results['dipole_moment'])

# Custom colormap and charge range
resp_drv.show(molecule, resp_charges, cmap='seismic', charge_max=0.5)

# Get the dipole moment as a numpy array
dip = resp_drv.get_dipole_moment(molecule, resp_charges)  # a.u. (e·bohr)
```