### PR TITLE
ValetAnalyzer: use rsp_results from checkpoint file

### DIFF
--- a/src/pymodule/valetanalyzer.py
+++ b/src/pymodule/valetanalyzer.py
@@ -157,12 +157,17 @@ class ValetAnalyzer:
         mo_occ = mo[:, :nocc].copy()
         mo_vir = mo[:, nocc:].copy()
 
-        # RPA vs TDA
+        str_s = "S%d" % state_index
+
+        # RPA vs TDA vs rsp_results from h5
         if 'eigenvectors_distributed' in rsp_results:
             eigvec = self.get_full_solution_vector(
                 rsp_results['eigenvectors_distributed'][state_index - 1])
         elif 'eigenvectors' in rsp_results:
             eigvec = rsp_results['eigenvectors'][:, state_index - 1].copy()
+        elif str_s in rsp_results:
+            # from h5 file
+            eigvec = rsp_results[str_s].copy()
 
         nexc = nocc * nvir
         z_mat = eigvec[:nexc]


### PR DESCRIPTION
ValetAnalyzer could not read the eigenvectors from an rsp_results dictionary read from checkpoint. This is because the vectors are stored with keys "S1", "S2", etc. instead of "eigenvectors"/"eigenvectors_distributed". I added the option to read based on the "S1", "S2", ... keys.

Jupyter notebook example: [valet_analysis_from_h5.ipynb](https://github.com/user-attachments/files/27337352/valet_analysis_from_h5.ipynb)

Checkpoint file used in the notebook: [thienyl_thiazole_tda.h5](https://drive.google.com/file/d/1mMmVXyp-aZsbuG4H35ijnFWwTZyEk6er/view?usp=sharing)