### PR TITLE
RixsDriver: restricted_subspace shouldn't be default

### DIFF
--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -99,7 +99,7 @@ class RixsDriver(LinearSolver):
         self.num_core_states = 5
 
         # Restricted subspace
-        self.restricted_subspace = True
+        self.restricted_subspace = False
 
         self.num_core_orbitals = 0
         self.num_virtual_orbitals = 0


### PR DESCRIPTION
This is a super-small change in RixsDriver. The "restricted_subspace" shouldn't be the default, since it is both more difficult to use and less reliable compared to the two-shot approach. In `restricted_subspace`, the results depend on the choice of subspace, where the user has to decide the occupied and virtual orbitals to include. It was implemented to test how the potential lack of orthonormalization of eigenvectors from two separate TDDFT calculations may affect RIXS and to be able to compare with results from literature that use this approach.
