### PR TITLE
Saved XPS results in h5 file, input file for XPS.

### DIFF
--- a/src/pymodule/main.py
+++ b/src/pymodule/main.py
@@ -852,17 +852,18 @@ def _main_body():
         xps_drv = XPSDriver(task.mpi_comm, task.ostream)
         xps_drv.update_settings(xps_dict, method_dict)
         element = xps_dict['element'] if 'element' in xps_dict else None
-        elements = xps_dict['elements'] if 'elements' in xps_dict else None
 
         assert_msg_critical(
-            element is not None or elements is not None,
-            'XPS task requires element or elements in the xps input group')
+            'elements' not in xps_dict,
+            'XPS task uses only element in the xps input group')
+
+        assert_msg_critical(element is not None,
+                            'XPS task requires element in the xps input group')
 
         xps_results = xps_drv.compute(task.molecule,
                                       task.ao_basis,
                                       scf_drv,
-                                      element=element,
-                                      elements=elements)
+                                      element=element)
         xps_drv.print_results(xps_results)
 
     # Cube file

--- a/src/pymodule/main.py
+++ b/src/pymodule/main.py
@@ -841,13 +841,16 @@ def _main_body():
     # XPS
 
     if task_type == 'xps':
+        assert_msg_critical(
+            not use_xtb,
+            'XPS task is not supported with xTB; please use an SCF/DFT method.')
+
         xps_dict = (dict(task.input_dict['xps'])
                     if 'xps' in task.input_dict else {})
         xps_dict['filename'] = task.input_dict['filename']
 
         xps_drv = XPSDriver(task.mpi_comm, task.ostream)
         xps_drv.update_settings(xps_dict, method_dict)
-
         element = xps_dict['element'] if 'element' in xps_dict else None
         elements = xps_dict['elements'] if 'elements' in xps_dict else None
 

--- a/src/pymodule/main.py
+++ b/src/pymodule/main.py
@@ -77,6 +77,7 @@ from .trajectorydriver import TrajectoryDriver
 from .xtbdriver import XtbDriver
 from .xtbgradientdriver import XtbGradientDriver
 from .xtbhessiandriver import XtbHessianDriver
+from .xpsdriver import XPSDriver
 from .cli import cli
 from .errorhandler import assert_msg_critical, VeloxChemError
 
@@ -374,7 +375,7 @@ def _main_body():
         'hf', 'rhf', 'uhf', 'rohf', 'scf', 'uscf', 'roscf', 'wavefunction',
         'wave function', 'mp2', 'ump2', 'romp2', 'gradient', 'uscf_gradient',
         'hessian', 'optimize', 'response', 'pulses', 'visualization', 'loprop',
-        'pe force field', 'vibrational', 'polarizability_gradient'
+        'pe force field', 'vibrational', 'polarizability_gradient', 'xps'
     ]
 
     run_scf_only = task_type in [
@@ -836,6 +837,30 @@ def _main_body():
         mp2_drv = Mp2Driver(task.mpi_comm, task.ostream)
         mp2_drv.update_settings(mp2_dict, method_dict)
         mp2_drv.compute(task.molecule, task.ao_basis, scf_results)
+
+    # XPS
+
+    if task_type == 'xps':
+        xps_dict = (dict(task.input_dict['xps'])
+                    if 'xps' in task.input_dict else {})
+        xps_dict['filename'] = task.input_dict['filename']
+
+        xps_drv = XPSDriver(task.mpi_comm, task.ostream)
+        xps_drv.update_settings(xps_dict, method_dict)
+
+        element = xps_dict['element'] if 'element' in xps_dict else None
+        elements = xps_dict['elements'] if 'elements' in xps_dict else None
+
+        assert_msg_critical(
+            element is not None or elements is not None,
+            'XPS task requires element or elements in the xps input group')
+
+        xps_results = xps_drv.compute(task.molecule,
+                                      task.ao_basis,
+                                      scf_drv,
+                                      element=element,
+                                      elements=elements)
+        xps_drv.print_results(xps_results)
 
     # Cube file
 

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -437,7 +437,13 @@ def plot_xps_spectrum(xps_results,
 
     :param xps_results:
         The dictionary containing XPS results from XPSDriver.compute().
-        Format: {element: [(mo_idx, atom_idx, ionization_energy, contribution), ...]}
+        Format: {element: [{
+            'mo_index': int,
+            'atom_index': int,
+            'ionization_energy_ev': float,
+            'contribution': float,
+            'is_delocalized': bool,
+        }, ...]}
     :param element:
         Element symbol to plot (e.g., 'C', 'O', 'N', 'F', 'S').
         If None and xps_results contains only one element, that element is plotted.
@@ -511,14 +517,9 @@ def plot_xps_spectrum(xps_results,
     else:
         elem_color = vlx_color
 
-    # Extract data for the specified element
-    # Handle both old format (mo_idx, ie) and new format (mo_idx, atom_idx, ie, contribution)
-    if len(ionization_data[0]) == 2:
-        energies = np.array([ie for _, ie in ionization_data])
-        atom_indices = None
-    else:
-        energies = np.array([ie for _, _, ie, _ in ionization_data])
-        atom_indices = np.array([atom_idx for _, atom_idx, _, _ in ionization_data])
+    energies = np.array(
+        [record['ionization_energy_ev'] for record in ionization_data])
+    atom_indices = np.array([record['atom_index'] for record in ionization_data])
     intensities = np.ones(len(energies))
 
     # Create or use provided axis

--- a/src/pymodule/xpsdriver.py
+++ b/src/pymodule/xpsdriver.py
@@ -31,7 +31,9 @@
 #  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from mpi4py import MPI
+from pathlib import Path
 import numpy as np
+import h5py
 import copy
 import sys
 
@@ -100,6 +102,7 @@ class XPSDriver:
 
         # Default to DFT ranges for backward compatibility
         self.energy_ranges = self.energy_ranges_dft
+        self.filename = None
 
     def update_settings(self, xps_dict, method_dict=None):
         """
@@ -114,11 +117,76 @@ class XPSDriver:
         if method_dict is None:
             method_dict = {}
 
-        xps_keywords = {}
+        xps_keywords = {
+            'filename': str,
+        }
 
         for key in xps_dict:
             if key in xps_keywords:
                 setattr(self, key, xps_dict[key])
+
+    @staticmethod
+    def _get_hdf5_results(results, requested_elements):
+        """
+        Creates the XPS results dictionary for HDF5 output.
+
+        :param results:
+            The results dictionary returned by compute().
+        :param requested_elements:
+            The list of requested element symbols.
+
+        :return:
+            The dictionary to be written under the xps HDF5 group.
+        """
+
+        h5_results = {}
+
+        for element in requested_elements:
+            ionization_data = results.get(element, [])
+            sorted_data = sorted(ionization_data, key=lambda x: x[1])
+
+            h5_results[element] = {
+                'mo_indices': np.array([entry[0] for entry in sorted_data],
+                                       dtype=int),
+                'atom_indices': np.array([entry[1] for entry in sorted_data],
+                                         dtype=int),
+                'ionization_energies_ev': np.array(
+                    [entry[2] for entry in sorted_data], dtype=float),
+            }
+
+        return h5_results
+
+    def _write_hdf5(self, fname, results, requested_elements):
+        """
+        Writes XPS results to the specified HDF5 file.
+
+        :param fname:
+            Name of the HDF5 file.
+        :param results:
+            The results dictionary returned by compute().
+        :param requested_elements:
+            The list of requested element symbols.
+        """
+
+        if not fname:
+            raise ValueError('No filename given to _write_hdf5()')
+
+        fpath = Path(fname)
+        if fpath.suffix != '.h5':
+            fpath = fpath.with_suffix('.h5')
+
+        datasets = self._get_hdf5_results(results, requested_elements)
+
+        with h5py.File(fpath, 'a') as hf:
+            if 'xps' in hf:
+                del hf['xps']
+
+            xps_group = hf.create_group('xps')
+            for element, element_data in datasets.items():
+                element_group = xps_group.create_group(element)
+
+                for key, value in element_data.items():
+                    element_group.create_dataset(key, data=value)
 
     @staticmethod
     def _get_xcfun_label(xcfun):
@@ -560,6 +628,10 @@ class XPSDriver:
             self.ostream.print_blank()
             self.ostream.print_header('*** XPS Calculation Completed.'.ljust(92))
             self.ostream.print_blank()
+            if self.filename is not None:
+                self.ostream.print_info('Writing to files...')
+                self.ostream.print_blank()
+                self._write_hdf5(self.filename, results, elements_list)
             self.ostream.flush()
 
         return results

--- a/src/pymodule/xpsdriver.py
+++ b/src/pymodule/xpsdriver.py
@@ -33,7 +33,6 @@
 from mpi4py import MPI
 from pathlib import Path
 import numpy as np
-import h5py
 import copy
 import sys
 
@@ -41,6 +40,7 @@ from .veloxchemlib import hartree_in_ev, mpi_master
 from .outputstream import OutputStream
 from .scfunrestdriver import ScfUnrestrictedDriver
 from .errorhandler import assert_msg_critical
+from .resultsio import write_results_to_hdf5
 from .spectrumplot import plot_xps_spectrum
 from .sanitychecks import scf_results_sanity_check
 
@@ -82,7 +82,7 @@ class XPSDriver:
 
         # TODO: can HF and DFT be combined in the same range?
         # Core orbital energy ranges (in Hartree) for different elements and methods
-        # Based on typical Hartree-Fock calculations
+        # Based on typical Hartree-Fock calculations, not heavily tested for HF. Ranges may need adjustment for different basis sets or methods and basis sets.
         self.energy_ranges_hf = {
             'C': (-11.8, -10.8),
             'N': (-15.9, -15.2),
@@ -102,6 +102,7 @@ class XPSDriver:
 
         # Default to DFT ranges for backward compatibility
         self.energy_ranges = self.energy_ranges_dft
+        self.localization_threshold = 0.75
         self.filename = None
 
     def update_settings(self, xps_dict, method_dict=None):
@@ -126,37 +127,42 @@ class XPSDriver:
                 setattr(self, key, xps_dict[key])
 
     @staticmethod
-    def _get_hdf5_results(results, requested_elements):
+    def _normalize_element_input(element):
         """
-        Creates the XPS results dictionary for HDF5 output.
+        Normalizes XPS element input to a list of element symbols.
 
-        :param results:
-            The results dictionary returned by compute().
-        :param requested_elements:
-            The list of requested element symbols.
+        :param element:
+            A single element string, a comma-separated string, or a sequence of
+            element strings.
 
         :return:
-            The dictionary to be written under the xps HDF5 group.
+            A list of element symbols.
         """
 
-        h5_results = {}
+        assert_msg_critical(element is not None,
+                            'XPSDriver.compute: Must specify element parameter.')
 
-        for element in requested_elements:
-            ionization_data = results.get(element, [])
-            sorted_data = sorted(ionization_data, key=lambda x: x[1])
+        if isinstance(element, str):
+            elements_list = [elem.strip() for elem in element.split(',')]
+        else:
+            assert_msg_critical(
+                isinstance(element, (list, tuple)),
+                'XPSDriver.compute: Invalid element input.')
+            elements_list = list(element)
 
-            h5_results[element] = {
-                'mo_indices': np.array([entry[0] for entry in sorted_data],
-                                       dtype=int),
-                'atom_indices': np.array([entry[1] for entry in sorted_data],
-                                         dtype=int),
-                'ionization_energies_ev': np.array(
-                    [entry[2] for entry in sorted_data], dtype=float),
-            }
+        assert_msg_critical(
+            len(elements_list) > 0 and all(isinstance(elem, str)
+                                           for elem in elements_list),
+            'XPSDriver.compute: Invalid element input.')
 
-        return h5_results
+        elements_list = [elem.strip() for elem in elements_list]
 
-    def _write_hdf5(self, fname, results, requested_elements):
+        assert_msg_critical(all(elem for elem in elements_list),
+                            'XPSDriver.compute: Invalid element input.')
+
+        return elements_list
+
+    def _write_final_hdf5(self, fname, results):
         """
         Writes XPS results to the specified HDF5 file.
 
@@ -164,29 +170,22 @@ class XPSDriver:
             Name of the HDF5 file.
         :param results:
             The results dictionary returned by compute().
-        :param requested_elements:
-            The list of requested element symbols.
         """
 
         if not fname:
-            raise ValueError('No filename given to _write_hdf5()')
+            raise ValueError('No filename given to _write_final_hdf5()')
 
         fpath = Path(fname)
         if fpath.suffix != '.h5':
             fpath = fpath.with_suffix('.h5')
 
-        datasets = self._get_hdf5_results(results, requested_elements)
+        if not fpath.is_file():
+            raise ValueError(f'XPS HDF5 file does not exist: {fpath}')
 
-        with h5py.File(fpath, 'a') as hf:
-            if 'xps' in hf:
-                del hf['xps']
-
-            xps_group = hf.create_group('xps')
-            for element, element_data in datasets.items():
-                element_group = xps_group.create_group(element)
-
-                for key, value in element_data.items():
-                    element_group.create_dataset(key, data=value)
+        write_results_to_hdf5(str(fpath),
+                              'xps',
+                              results,
+                              value_label='XPS result')
 
     @staticmethod
     def _get_xcfun_label(xcfun):
@@ -441,7 +440,7 @@ class XPSDriver:
 
         return assignments
 
-    def compute(self, molecule, basis, scf_driver, element=None, elements=None):
+    def compute(self, molecule, basis, scf_driver, element=None):
         """
         Computes core ionization energies for specified element(s) using
         the full core-hole (FCH) approximation.
@@ -453,36 +452,16 @@ class XPSDriver:
         :param scf_driver:
             The converged SCF driver object (e.g., ScfRestrictedDriver).
         :param element:
-            Single element as string (e.g., 'C', 'O', 'N', 'S').
-        :param elements:
-            List of element symbols (e.g., ['C', 'O']).
+            Element selection as a single symbol (e.g., 'O'), a comma-separated
+            string (e.g., 'C,O'), or a sequence of symbols
+            (e.g., ['C', 'O']).
 
         :return:
-            Dictionary with element as key and list of (orbital_index, ionization_energy)
-            tuples as value. Ionization energies are in eV.
+            Dictionary with element as key and a list of per-orbital result
+            dictionaries as value. Ionization energies are in eV.
         """
 
-        # Handle both element (single string) and elements (list)
-        if element is not None and elements is not None:
-            assert_msg_critical(
-                False,
-                'XPSDriver.compute: Specify either element or elements, not both.')
-
-        if element is None and elements is None:
-            assert_msg_critical(
-                False,
-                'XPSDriver.compute: Must specify either element or elements parameter.')
-
-        if element is not None:
-            assert_msg_critical(
-                isinstance(element, str),
-                'XPSDriver.compute: Invalid element input.')
-            elements_list = [element]
-        elif elements is not None:
-            assert_msg_critical(
-                isinstance(elements, (list, tuple)),
-                'XPSDriver.compute: Invalid elements input.')
-            elements_list = list(elements)
+        elements_list = self._normalize_element_input(element)
 
         # Detect method type (HF or DFT)
         method_type = self._detect_method_type(scf_driver.xcfun)
@@ -555,7 +534,7 @@ class XPSDriver:
                     for mo_idx, atom_idx, contrib in core_orbital_assignments:
                         self.ostream.print_info(
                             f'  MO {mo_idx} -> Atom {atom_idx+1} ({elem}) with {contrib:.1%} contribution')
-                        if contrib < 0.75:
+                        if contrib < self.localization_threshold:
                             delocalized.append(mo_idx)
                     if delocalized:
                         # TODO: Localize orbitals. If multiple edges, core orbitals must be
@@ -614,7 +593,13 @@ class XPSDriver:
                 # Calculate core ionization energy (in eV)
                 ie = (fch_energy - gs_energy) * hartree_in_ev()
 
-                ionization_energies.append((mo_index, atom_index, ie, contribution))
+                ionization_energies.append({
+                    'mo_index': mo_index,
+                    'atom_index': atom_index,
+                    'ionization_energy_ev': ie,
+                    'contribution': contribution,
+                    'is_delocalized': bool(contribution < self.localization_threshold),
+                })
 
                 if self.rank == mpi_master():
                     self.ostream.print_info(
@@ -631,7 +616,7 @@ class XPSDriver:
             if self.filename is not None:
                 self.ostream.print_info('Writing to files...')
                 self.ostream.print_blank()
-                self._write_hdf5(self.filename, results, elements_list)
+                self._write_final_hdf5(self.filename, results)
             self.ostream.flush()
 
         return results
@@ -660,9 +645,13 @@ class XPSDriver:
             self.ostream.print_info('-' * 80)
 
             # Sort by atom index for better readability
-            sorted_data = sorted(ionization_data, key=lambda x: x[1])
+            sorted_data = sorted(ionization_data, key=lambda x: x['atom_index'])
 
-            for mo_idx, atom_idx, ie, contribution in sorted_data:
+            for record in sorted_data:
+                mo_idx = record['mo_index']
+                atom_idx = record['atom_index']
+                ie = record['ionization_energy_ev']
+                contribution = record['contribution']
                 self.ostream.print_info(
                     f'{atom_idx+1:<8} {mo_idx:<12} {ie:>12.2f}   {contribution:>13.1%}')
 

--- a/src/pymodule/xpsdriver.py
+++ b/src/pymodule/xpsdriver.py
@@ -84,11 +84,11 @@ class XPSDriver:
         # Core orbital energy ranges (in Hartree) for different elements and methods
         # Based on typical Hartree-Fock calculations
         self.energy_ranges_hf = {
-            'C': (-11.5, -11.0),
-            'N': (-15.7, -15.6),
-            'O': (-20.7, -20.5),
-            'F': (-26.4, -26.3),
-            'S': (-92.0, -91.0),
+            'C': (-11.8, -10.8),
+            'N': (-15.9, -15.2),
+            'O': (-21.2, -20.2),
+            'F': (-26.9, -26.1),
+            'S': (-92.0, -89.0),
         }
 
         # Based on typical DFT (B3LYP/PBE) calculations

--- a/tests/test_xps.py
+++ b/tests/test_xps.py
@@ -1,7 +1,9 @@
 from mpi4py import MPI
 import pytest
+import h5py
 
 from veloxchem.veloxchemlib import mpi_master
+from veloxchem.resultsio import read_results
 from veloxchem.molecule import Molecule
 from veloxchem.molecularbasis import MolecularBasis
 from veloxchem.scfrestdriver import ScfRestrictedDriver
@@ -42,12 +44,15 @@ class TestXpsDriver:
             assert list(xps_results.keys()) == ['O']
             assert len(xps_results['O']) == 1
 
-            mo_index, atom_index, ionization_energy, contribution = xps_results['O'][0]
+            record = xps_results['O'][0]
 
-            assert mo_index == 0
-            assert atom_index == 0
-            assert contribution == pytest.approx(0.6004496392, abs=1.0e-6)
-            assert ionization_energy == pytest.approx(539.249, abs=1.0e-2)
+            assert record['mo_index'] == 0
+            assert record['atom_index'] == 0
+            assert record['contribution'] == pytest.approx(0.6004496392,
+                                                           abs=1.0e-6)
+            assert record['ionization_energy_ev'] == pytest.approx(539.249,
+                                                                    abs=1.0e-2)
+            assert record['is_delocalized'] is True
 
     @staticmethod
     def get_methanol_and_basis():
@@ -76,23 +81,105 @@ class TestXpsDriver:
 
         xps_drv = XPSDriver()
         xps_drv.ostream.mute()
-        xps_results = xps_drv.compute(molecule, basis, scf_drv, elements=['O', 'C'])
+        xps_results = xps_drv.compute(molecule, basis, scf_drv, element=['O', 'C'])
 
         if MPI.COMM_WORLD.Get_rank() == mpi_master():
             assert list(xps_results.keys()) == ['O', 'C']
             assert len(xps_results['O']) == 1
             assert len(xps_results['C']) == 1
 
-            mo_index, atom_index, ionization_energy, contribution = xps_results['O'][0]
+            oxygen_record = xps_results['O'][0]
 
-            assert mo_index == 0
-            assert atom_index == 1
-            assert contribution == pytest.approx(0.9824145671, abs=1.0e-6)
-            assert ionization_energy == pytest.approx(540.410, abs=1.0e-2)
+            assert oxygen_record['mo_index'] == 0
+            assert oxygen_record['atom_index'] == 1
+            assert oxygen_record['contribution'] == pytest.approx(0.9824145671,
+                                                                  abs=1.0e-6)
+            assert oxygen_record['ionization_energy_ev'] == pytest.approx(
+                540.410, abs=1.0e-2)
+            assert oxygen_record['is_delocalized'] is False
 
-            mo_index, atom_index, ionization_energy, contribution = xps_results['C'][0]
+            carbon_record = xps_results['C'][0]
 
-            assert mo_index == 1
-            assert atom_index == 0
-            assert contribution == pytest.approx(0.9837630584, abs=1.0e-6)
-            assert ionization_energy == pytest.approx(293.989, abs=1.0e-2)
+            assert carbon_record['mo_index'] == 1
+            assert carbon_record['atom_index'] == 0
+            assert carbon_record['contribution'] == pytest.approx(0.9837630584,
+                                                                  abs=1.0e-6)
+            assert carbon_record['ionization_energy_ev'] == pytest.approx(
+                293.989, abs=1.0e-2)
+            assert carbon_record['is_delocalized'] is False
+
+    def test_xps_results_hdf5_roundtrip(self, tmp_path):
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        h5file = tmp_path / 'xps_results.h5'
+        with h5py.File(h5file, 'w'):
+            pass
+
+        xps_results = {
+            'O': [{
+                'mo_index': 0,
+                'atom_index': 0,
+                'ionization_energy_ev': 539.249,
+                'contribution': 0.6004496392,
+                'is_delocalized': True,
+            }],
+            'C': [{
+                'mo_index': 1,
+                'atom_index': 2,
+                'ionization_energy_ev': 293.989,
+                'contribution': 0.9837630584,
+                'is_delocalized': False,
+            }, {
+                'mo_index': 3,
+                'atom_index': 1,
+                'ionization_energy_ev': 295.123,
+                'contribution': 0.5123,
+                'is_delocalized': True,
+            }],
+        }
+
+        xps_drv = XPSDriver()
+        xps_drv.ostream.mute()
+        xps_drv._write_final_hdf5(str(h5file), xps_results)
+
+        recovered = read_results(str(h5file), 'xps')
+
+        assert recovered.keys() == xps_results.keys()
+        for element in xps_results:
+            assert recovered[element] == xps_results[element]
+
+    def test_xps_results_hdf5_roundtrip_without_suffix(self, tmp_path):
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        h5stem = tmp_path / 'xps_results'
+        h5file = tmp_path / 'xps_results.h5'
+        with h5py.File(h5file, 'w'):
+            pass
+
+        xps_results = {
+            'O': [{
+                'mo_index': 0,
+                'atom_index': 0,
+                'ionization_energy_ev': 539.249,
+                'contribution': 0.6004496392,
+                'is_delocalized': True,
+            }],
+        }
+
+        xps_drv = XPSDriver()
+        xps_drv.ostream.mute()
+        xps_drv._write_final_hdf5(str(h5stem), xps_results)
+
+        recovered = read_results(str(h5file), 'xps')
+
+        assert recovered == xps_results
+
+    def test_normalize_element_input(self):
+
+        assert XPSDriver._normalize_element_input('O,C,F') == ['O', 'C', 'F']
+        assert XPSDriver._normalize_element_input('O, C, F') == ['O', 'C', 'F']
+        assert XPSDriver._normalize_element_input(['C', 'O', 'F']) == ['C', 'O', 'F']


### PR DESCRIPTION
# Add XPS input-file entry point and HDF5 output

## Summary
This PR exposes XPS as an input-file driven workflow and writes XPS results to the main HDF5 file.

The changes add a top-level `xps` task in `src/pymodule/main.py` and extend `src/pymodule/xpsdriver.py` to save XPS results under per-element HDF5 groups:
- `xps/<element>/mo_indices`
- `xps/<element>/atom_indices`
- `xps/<element>/ionization_energies_ev`

## Details
- add `XPSDriver` dispatch to the main input-file execution path
- include `xps` among SCF-backed tasks so the XPS workflow runs after a ground-state SCF
- add `filename` handling to `XPSDriver`
- write XPS results to the existing HDF5 file using a flat per-element layout under `xps/`
- keep the stored data minimal and aligned with the printed XPS table

## Example Input
```text
@jobs
task: xps
@end

@method settings
basis: def2-svp
xcfun: b3lyp
@end

@xps
element: O
@end

@molecule
charge: 0
multiplicity: 1
unit: ang
xyz:
O     0.000000    0.000000    0.000000
H     0.000000    0.757000    0.586000
H     0.000000   -0.757000    0.586000
@end
```
