### PR TITLE
Add DescriptorDriver and export it in pymodule init

### DIFF
--- a/src/pymodule/__init__.py
+++ b/src/pymodule/__init__.py
@@ -225,6 +225,7 @@ from .atombdedriver import AtomBdeDriver
 from .orbitallocalization import OrbitalLocalizationDriver
 from .ensembleparser import EnsembleParser
 from .ensembledriver import EnsembleDriver
+from .descriptordriver import DescriptorDriver
 from .spectrumaverager import SpectrumAverager
 # for backward compatibility only
 from .cppsolver import ComplexResponseSolver as ComplexResponse

--- a/src/pymodule/__init__.py
+++ b/src/pymodule/__init__.py
@@ -241,7 +241,8 @@ from .oneeints import compute_nuclear_potential_integrals
 from .oneeints import compute_electric_dipole_integrals
 from .oneeints import compute_linear_momentum_integrals
 from .oneeints import compute_angular_momentum_integrals
-from .resultsio import read_molecule_and_basis, read_results
+from .resultsio import (read_descriptor_results, read_molecule_and_basis,
+                        read_results, write_descriptor_results_to_hdf5)
 
 # Environment variable: basis set path, number of OpenMP threads
 from .environment import (set_vlxbasispath, get_basis_path, set_vlxdatapath,

--- a/src/pymodule/descriptordriver.py
+++ b/src/pymodule/descriptordriver.py
@@ -1,0 +1,365 @@
+from collections import defaultdict
+import numpy as np
+import veloxchem as vlx
+
+
+class DescriptorDriver:
+    def __init__(self):
+        self.molecule = None       #molecule for descriptor calculation
+        self.basis = None          
+        self.scf_drv = None        
+        self.scf_results = None    
+        
+        self.molgrid = None                     
+        self.surface_points = None            
+        self.point_atom_indices = None        
+
+        self.occ_mo_points_amplitude = []      #MO amplitude for occupied orbitals in every point
+        
+        self.unocc_mo_points_amplitude = []    #MO amplitude for unoccupied orbitals in every point
+
+
+        self.ea_values = []
+        self.ie_values = []
+
+        self.atomtypes = []                    #List containing atomtypes of all atoms according to amber atomtypes in GAFF (atom indices 1 - n)
+        self.SASA = None                       #Solvent-accessible surface area (Å^2) 
+        self.log_p = None
+
+        self.resp_charges = None
+        self.atom_indices = None
+        
+
+        self.ea_ie_results = None
+
+        self.results_dict = {}
+
+
+
+
+
+    def compute_respcharges(self):
+                # RESP computation
+        resp_drv = vlx.RespChargesDriver()
+        resp_basis = vlx.MolecularBasis.read(self.molecule, "6-31G*")
+        self.resp_charges = resp_drv.compute(self.molecule, resp_basis)
+        
+        
+    
+   
+    
+
+    #Work-around for vlx.XCIntegrator in order to apply it to cpcm grid. 
+    def compute_gto_values_at_custom_points(self, custom_points: np.ndarray):
+        """
+        custom_points: numpy array of shape (N, 3) in bohr
+        """
+       
+        weights = np.ones(len(custom_points))
+
+        # 2. Stack them into a (4, N) array
+        # Use np.vstack to stack the x, y, z, and weights vertically
+        molgrid_points = np.vstack((
+        custom_points[:, 0],  # row 0: x
+        custom_points[:, 1],  # row 1: y
+        custom_points[:, 2],  # row 2: z
+        weights               # row 3: weights
+        ))
+        from veloxchem.veloxchemlib import DenseMatrix, MolecularGrid
+
+       
+
+
+        coords_mat = DenseMatrix(molgrid_points)
+        mol_grid = MolecularGrid(coords_mat)
+
+
+        mol_grid.partition_grid_points()
+        mol_grid.distribute_counts_and_displacements(0, 1) 
+
+        xc_drv = vlx.XCIntegrator()
+        chi_g = xc_drv.compute_gto_values(self.molecule, self.basis, mol_grid)
+        
+        return chi_g
+    
+
+
+
+    def create_surface_points(self):
+        
+        cpcm_drv = vlx.CpcmDriver()
+        
+        raw_cpcm_points = cpcm_drv.generate_cpcm_grid(self.molecule)
+        self.molgrid = raw_cpcm_points[0][:, :3]
+        chi_g = self.compute_gto_values_at_custom_points(self.molgrid)   #finds which basis functions (GTOs) in what grid point?
+
+        D = self.scf_results['D_alpha'] + self.scf_results['D_beta'] #total electron density matrix (alpha and beta spin)
+        G = np.einsum("ab,bg->ag", D, chi_g)       #Here we evaluate each grid-point with weighted basis functions. N_basis X N_gridpoints
+        n_g = np.einsum("ag,ag->g", chi_g, G)      #1-D array of electorn densities in the different points 
+    
+        self.surface_points = np.column_stack((self.molgrid[:, 0], self.molgrid[:, 1], self.molgrid[:, 2])) 
+        print(f'No. of surface points created: {len(self.surface_points)}')
+        
+
+
+
+
+
+    def assign_points_to_atoms(self):
+        atom_positions = self.molecule.get_coordinates_in_bohr()
+        atom_vdw_radii = self.molecule.vdw_radii_to_numpy()  # Get van der Waals radii for each atom in bohr
+
+        point_atom_indices = []
+        for point in self.surface_points:
+            distances = np.linalg.norm(atom_positions - point, axis=1)     # Calculate distances from this point to all atoms
+            adjusted_distances = distances - atom_vdw_radii      # Adjust distances by subtracting van der Waals radii
+            closest_atom_index = np.argmin(adjusted_distances)       # Find the index of the closest atom considering van der Waals radii
+            point_atom_indices.append(closest_atom_index)
+
+        self.point_atom_indices = point_atom_indices
+        
+        #check that amount of surface points equals the no. of point-to-atom indices 
+        assert len(self.surface_points) == len(self.point_atom_indices), \
+        f"Mismatch! Created {len(self.surface_points)} surface points " \
+        f"but generated {len(self.point_atom_indices)} point-to-atom indices"
+
+
+
+    def molecular_orbital_amplitude_per_point(self):
+        
+        chi_g = self.compute_gto_values_at_custom_points(self.molgrid)
+        mol_orb_coeff = self.scf_results["C_alpha"]
+
+        occ_orb = sum(self.scf_results['occ_alpha'])   
+        tot_orb = len(self.scf_results['occ_alpha'])
+
+        for i in range(int(occ_orb)):                              #for occupied orbitals
+            mo_val = np.dot(chi_g.T, mol_orb_coeff[:, i])   # Atomic orbitals amplitude (per point in gid) * Coeffients for linnearily combining AO into MO = MO amplitude in each point
+            self.occ_mo_points_amplitude.append(mo_val)
+
+        for i in range(int(occ_orb), int(tot_orb)):                     #same
+            mo_val = np.dot(chi_g.T, mol_orb_coeff[:, i])
+            self.unocc_mo_points_amplitude.append(mo_val)
+                
+
+    def compute_IE_and_EA(self):
+        energy_occ = self.scf_results['E_alpha'][:int(sum(self.scf_results['occ_alpha']))]    # Energies (Hartree) of occupied alpha MOs as calculated by scfdrver    
+        energy_unocc = self.scf_results['E_alpha'][int(sum(self.scf_results['occ_alpha'])):] # Energies (Hartree) of virtual (empty) alpha MOs as calculated by scfdrver
+         
+        for idx, point in enumerate(self.surface_points):     #loop over all the surface points, keeping idx to find the correct surface point for every MO in "self.unocc_mo_points_amplitude"
+            
+            ea_point_numerator, ea_point_denominator  = 0, 0 # Initialize 
+
+            for j in range(len(self.unocc_mo_points_amplitude)):  #Loop over  all unoccupied MOs; LUMO, LUMO+1, etc and their amplitude in every point [[MO1: p1, p2 ... pn], [MO2 p1, p2 ... pn]]
+
+                unocc_mo_ampl_squared = (self.unocc_mo_points_amplitude[j][idx])**2         #squared cumulative amplitude for LUMO1 point1, LUMO2 point 1, LUMO3 point1 until LUMOn, point n
+
+                ea_point_numerator += (unocc_mo_ampl_squared * energy_unocc[j])        #sum of squared amplitudes x virtual orbital energy
+                ea_point_denominator += unocc_mo_ampl_squared                          #sum of squared amplitudes
+
+            ea = (-ea_point_numerator / ea_point_denominator )* 27.211407953              #Hartree to eV
+            self.ea_values.append(ea)  
+
+
+            ie_point_numerator, ie_point_denominator  = 0, 0 # Initialize 
+
+            for j in range(len(self.occ_mo_points_amplitude)):  #Loop over  all occupied MOs and their amplitude in every point [[MO1: p1, p2 ... pn], [MO2 p1, p2 ... pn]]
+
+                occ_mo_ampl_squared = (self.occ_mo_points_amplitude[j][idx])**2         #squared cumulative amplitude 
+
+                ie_point_numerator += (occ_mo_ampl_squared * abs(energy_occ[j]))        #sum of squared amplitudes x orbital energy
+                ie_point_denominator += occ_mo_ampl_squared                          #sum of squared amplitudes
+
+                 
+            ie = (ie_point_numerator/ie_point_denominator)* 27.211407953            #Hartree to eV
+            self.ie_values.append(ie)
+
+        print(f'{len(self.ea_values)}, {len(self.ie_values)} values of electron affinity and ionization energy calculated for {len(self.surface_points)} surface points ')
+
+
+
+
+    def compute_atom_statistics(self):
+
+        # Create point-level data
+        point_data = []
+        for i in range(len(self.surface_points)):
+            point_data.append({
+                'point_index': i + 1,
+                'atom_label': self.molecule.get_label(self.point_atom_indices[i]),
+                'atom_index': int(self.point_atom_indices[i]),
+                'IE': self.ie_values[i],
+                'EA': self.ea_values[i]
+            })
+        
+        # Group by atom for statistics
+        ea_data = defaultdict(list)
+        ie_data = defaultdict(list)
+        
+        for point in point_data:
+            atom_idx = point['atom_index']
+            ea_data[atom_idx].append(point['EA'])
+            ie_data[atom_idx].append(point['IE'])
+        
+        # Calculate per-atom statistics
+        atom_statistics = {}
+        
+        for atom in range(len(self.molecule.get_labels())):
+            print(f'Atom : {atom}')
+            if not ea_data[atom] or not ie_data[atom]:
+                atom_statistics[atom] = {
+                    'min_EA': np.nan,
+                    'max_EA': np.nan,
+                    'mean_EA': np.nan,
+                    'std_EA': np.nan,
+                    'n_points': 0,
+                    'min_IE': np.nan,
+                    'max_IE': np.nan,
+                    'mean_IE': np.nan,
+                    'std_IE': np.nan
+                }
+                continue
+            atom_statistics[atom] = {
+                'min_EA': min(ea_data[atom]),
+                'max_EA': max(ea_data[atom]),
+                'mean_EA': np.mean(ea_data[atom]),
+                'std_EA': np.std(ea_data[atom]),
+                'n_points': len(ea_data[atom]),
+                'min_IE': min(ie_data[atom]),
+                'max_IE': max(ie_data[atom]),
+                'mean_IE': np.mean(ie_data[atom]),
+                'std_IE': np.std(ie_data[atom])
+            }
+        
+        # Store in self.results
+        self.ea_ie_results = atom_statistics
+        
+        
+
+        
+    def define_atom_types(self):                           #Uses AtomTypeIdentifier to categorize each atom according to GAFF
+        atomtypeidentifier = vlx.AtomTypeIdentifier()
+        self.atomtypes = atomtypeidentifier.generate_gaff_atomtypes(self.molecule)
+
+
+
+
+    def compute_log_p_and_SASA(self): 
+    
+
+        #SASA calculation
+        smd = vlx.SmdDriver()
+        smd.solute = self.molecule
+        sasa_list = smd._get_SASA()
+        self.sasa = sum(sasa_list) # Å^2
+
+        #Calc scf energy for water solvation
+        basis = vlx.MolecularBasis.read(self.molecule, 'def2-svp')
+
+        scf_drv = vlx.ScfRestrictedDriver()
+        scf_drv.xcfun = 'b3lyp'
+        scf_drv.solvation_model = 'smd'
+        scf_drv.smd_solvent = 'water'
+
+        scf_results_water = scf_drv.compute(self.molecule, basis)
+
+        #Calc scf energy for octanol solvation
+        basis = vlx.MolecularBasis.read(self.molecule, 'def2-svp')
+
+        scf_drv = vlx.ScfRestrictedDriver()
+        scf_drv.xcfun = 'b3lyp'
+        scf_drv.solvation_model = 'smd'
+        scf_drv.smd_solvent = '1-octanol'
+
+        scf_results_octanol = scf_drv.compute(self.molecule, basis)
+        
+
+        #calculate log p
+        hartree_to_j_mol = 2625500.2
+        R = 8.3144626  # J / (mol * K)
+        T = 298.15     # Kelvin
+
+ 
+        ddg_solv_hartree  = scf_results_octanol['scf_energy'] - scf_results_water['scf_energy']
+        ddg_solv_j_mol = ddg_solv_hartree * hartree_to_j_mol
+
+        self.log_p = -ddg_solv_j_mol / (np.log(10) * R * T)
+
+
+
+    def compile_results(self):
+        
+        self.results_dict['IE_EA'] = self.ea_ie_results
+        self.results_dict['atomtypes'] = self.atomtypes
+        self.results_dict['log_p'] = self.log_p
+        self.results_dict['sasa'] = self.sasa
+        self.results_dict['RESP_charges'] = self.resp_charges
+        self.results_dict['ie_surface_average'] = np.mean(self.ie_values)
+        self.results_dict['ea_surface_average'] = np.mean(self.ea_values)
+        self.results_dict['scf_results'] = self.scf_results
+
+
+        
+
+
+
+
+
+
+
+
+
+    def compute_descriptors(self, molecule, basis=None, scf_drv=None, scf_results = None):
+        self.molecule = molecule
+
+
+        # Create basis if not provided
+        if basis is None:
+            basis = vlx.MolecularBasis.read(molecule, 'def2-svpd')
+        self.basis = basis
+    
+        # instantiate SCF driver if not provided  
+        if scf_drv is None:
+            scf_drv = vlx.ScfRestrictedDriver()
+            scf_drv.xcfun = 'b3lyp'
+        self.scf_drv = scf_drv
+        
+        if scf_results is None:
+            scf_results = scf_drv.compute(self.molecule, self.basis)  #electronic structure needed to find surface grid
+        self.scf_results = scf_results
+ 
+      
+        # Compute RESP charges for all geometries
+        print(f"computing RESP-charges...")
+        self.compute_respcharges()    
+
+        #compute surface points for molecule
+        print(f"Creating surface grid...")
+        self.create_surface_points()
+        
+        #assign each point to closest atom
+        print(f"Assigning grid points to atoms...")
+        self.assign_points_to_atoms()
+
+        #calculate molecular orbital amplitude at each point
+        print(f"Computing atomic IE and EA enegies...")
+        self.molecular_orbital_amplitude_per_point()
+
+        self.compute_IE_and_EA()    #eV
+
+        # Compute atom statistics and store in self.results
+        
+        self.compute_atom_statistics()
+
+
+
+        # Define atomtypes in molecule
+        self.define_atom_types()
+
+
+       # self.compute_log_p_and_SASA()
+        self.compute_log_p_and_SASA() 
+        self.compile_results()
+
+
+        return self.results_dict

--- a/src/pymodule/descriptordriver.py
+++ b/src/pymodule/descriptordriver.py
@@ -1,365 +1,364 @@
+"""Driver for computing atom- and molecule-level QM/empirical descriptors."""
+ 
 from collections import defaultdict
+from typing import Any, Dict, Optional
+ 
 import numpy as np
 import veloxchem as vlx
-
-
+ 
+ 
+# Unit conversion / physical constants used below.
+HARTREE_TO_EV = 27.211407953
+HARTREE_TO_J_PER_MOL = 2625500.2
+GAS_CONSTANT_J_PER_MOL_K = 8.3144626  # R
+ROOM_TEMPERATURE_K = 298.15
+ 
+ 
 class DescriptorDriver:
+    """
+    Computes a set of atom- and molecule-level descriptors from a converged
+    SCF calculation:
+ 
+    - RESP atomic partial charges
+    - Local surface ionization energy (IE) and electron affinity (EA),
+      evaluated on a CPCM-derived molecular surface and averaged per atom
+    - GAFF atom types
+    - logP (water / 1-octanol) and total SASA
+ 
+    Typical usage
+    -------------
+        driver = DescriptorDriver()
+        results = driver.compute_descriptors(molecule)
+    """
+ 
     def __init__(self):
-        self.molecule = None       #molecule for descriptor calculation
-        self.basis = None          
-        self.scf_drv = None        
-        self.scf_results = None    
-        
-        self.molgrid = None                     
-        self.surface_points = None            
-        self.point_atom_indices = None        
-
-        self.occ_mo_points_amplitude = []      #MO amplitude for occupied orbitals in every point
-        
-        self.unocc_mo_points_amplitude = []    #MO amplitude for unoccupied orbitals in every point
-
-
+        self.molecule = None       # molecule for descriptor calculation
+        self.basis = None
+        self.scf_drv = None
+        self.scf_results = None
+ 
+        self.molgrid = None
+        self.surface_points = None
+        self.point_atom_indices = None
+        self.occ_mo_points_amplitude = []      # MO amplitude for occupied orbitals, per point
+        self.unocc_mo_points_amplitude = []    # MO amplitude for unoccupied orbitals, per point
         self.ea_values = []
         self.ie_values = []
-
-        self.atomtypes = []                    #List containing atomtypes of all atoms according to amber atomtypes in GAFF (atom indices 1 - n)
-        self.SASA = None                       #Solvent-accessible surface area (Å^2) 
+        self.atomtypes = []                    # GAFF atom types, indexed like self.molecule's atoms
+        self.sasa = None                       # Solvent-accessible surface area (Å^2)
         self.log_p = None
-
         self.resp_charges = None
-        self.atom_indices = None
-        
-
+ 
         self.ea_ie_results = None
-
         self.results_dict = {}
-
-
-
-
-
+ 
+        # Level of theory for the auxiliary logP calculation. Deliberately
+        # decoupled from self.basis/self.scf_drv: logP is estimated from a
+        # water/1-octanol solvation free-energy difference, which is
+        # conventionally computed at a fixed reference level of theory
+        # rather than whatever level the caller chose for the main
+        # calculation. Override on the instance before calling
+        # compute_descriptors() if you need something else.
+        self.logp_basis_label = "def2-svp"
+        self.logp_xcfun = "b3lyp"
+ 
+        # Basis used for the RESP charge fit. Same rationale as above.
+        self.resp_basis_label = "6-31G*"
+ 
     def compute_respcharges(self):
-                # RESP computation
+        """Compute RESP atomic partial charges and store them in self.resp_charges."""
         resp_drv = vlx.RespChargesDriver()
-        resp_basis = vlx.MolecularBasis.read(self.molecule, "6-31G*")
+        resp_basis = vlx.MolecularBasis.read(self.molecule, self.resp_basis_label)
         self.resp_charges = resp_drv.compute(self.molecule, resp_basis)
-        
-        
-    
-   
-    
-
-    #Work-around for vlx.XCIntegrator in order to apply it to cpcm grid. 
-    def compute_gto_values_at_custom_points(self, custom_points: np.ndarray):
+ 
+    def compute_gto_values_at_custom_points(self, custom_points: np.ndarray) -> np.ndarray:
         """
-        custom_points: numpy array of shape (N, 3) in bohr
+        Evaluate the GTO basis functions at an arbitrary set of points.
+ 
+        Work-around for vlx.XCIntegrator, which normally operates on its own
+        internally generated grid — this lets us reuse it on the CPCM
+        surface grid instead (which showed less instability with respect to 
+        grid density compared to molgridriver).
+ 
+        Parameters
+        ----------
+        custom_points
+            Array of shape (N, 3), point coordinates in bohr.
+ 
+        Returns
+        -------
+        np.ndarray
+            GTO values at each point, shape (n_basis_functions, N).
         """
-       
-        weights = np.ones(len(custom_points))
-
-        # 2. Stack them into a (4, N) array
-        # Use np.vstack to stack the x, y, z, and weights vertically
-        molgrid_points = np.vstack((
-        custom_points[:, 0],  # row 0: x
-        custom_points[:, 1],  # row 1: y
-        custom_points[:, 2],  # row 2: z
-        weights               # row 3: weights
-        ))
         from veloxchem.veloxchemlib import DenseMatrix, MolecularGrid
-
-       
-
-
+ 
+        weights = np.ones(len(custom_points))
+        molgrid_points = np.vstack((
+            custom_points[:, 0],
+            custom_points[:, 1],
+            custom_points[:, 2],
+            weights,
+        ))
+ 
         coords_mat = DenseMatrix(molgrid_points)
         mol_grid = MolecularGrid(coords_mat)
-
-
         mol_grid.partition_grid_points()
-        mol_grid.distribute_counts_and_displacements(0, 1) 
-
+        mol_grid.distribute_counts_and_displacements(0, 1)
+ 
         xc_drv = vlx.XCIntegrator()
         chi_g = xc_drv.compute_gto_values(self.molecule, self.basis, mol_grid)
-        
         return chi_g
-    
-
-
-
+ 
     def create_surface_points(self):
-        
+        """Generate a CPCM molecular surface grid and store it in self.surface_points."""
         cpcm_drv = vlx.CpcmDriver()
-        
         raw_cpcm_points = cpcm_drv.generate_cpcm_grid(self.molecule)
         self.molgrid = raw_cpcm_points[0][:, :3]
-        chi_g = self.compute_gto_values_at_custom_points(self.molgrid)   #finds which basis functions (GTOs) in what grid point?
-
-        D = self.scf_results['D_alpha'] + self.scf_results['D_beta'] #total electron density matrix (alpha and beta spin)
-        G = np.einsum("ab,bg->ag", D, chi_g)       #Here we evaluate each grid-point with weighted basis functions. N_basis X N_gridpoints
-        n_g = np.einsum("ag,ag->g", chi_g, G)      #1-D array of electorn densities in the different points 
-    
-        self.surface_points = np.column_stack((self.molgrid[:, 0], self.molgrid[:, 1], self.molgrid[:, 2])) 
-        print(f'No. of surface points created: {len(self.surface_points)}')
-        
-
-
-
-
-
+ 
+        chi_g = self.compute_gto_values_at_custom_points(self.molgrid)
+        D = self.scf_results["D_alpha"] + self.scf_results["D_beta"]  # total electron density matrix
+        G = np.einsum("ab,bg->ag", D, chi_g)
+        n_g = np.einsum("ag,ag->g", chi_g, G)  
+ 
+        self.surface_points = self.molgrid.copy()
+        print(f"No. of surface points created: {len(self.surface_points)}")
+ 
     def assign_points_to_atoms(self):
-        atom_positions = self.molecule.get_coordinates_in_bohr()
-        atom_vdw_radii = self.molecule.vdw_radii_to_numpy()  # Get van der Waals radii for each atom in bohr
-
+        """
+        Assign each surface point to its nearest atom, using van der Waals
+        radius-adjusted distances, and store the result in
+        self.point_atom_indices (same length as self.surface_points).
+        """
+        atom_positions = self.molecule.get_coordinates_in_bohr()      # (n_atoms, 3)
+        atom_vdw_radii = self.molecule.vdw_radii_to_numpy()           # (n_atoms,)
+ 
         point_atom_indices = []
         for point in self.surface_points:
-            distances = np.linalg.norm(atom_positions - point, axis=1)     # Calculate distances from this point to all atoms
-            adjusted_distances = distances - atom_vdw_radii      # Adjust distances by subtracting van der Waals radii
-            closest_atom_index = np.argmin(adjusted_distances)       # Find the index of the closest atom considering van der Waals radii
+            distances = np.linalg.norm(atom_positions - point, axis=1)
+            adjusted_distances = distances - atom_vdw_radii
+            closest_atom_index = np.argmin(adjusted_distances)
             point_atom_indices.append(closest_atom_index)
-
         self.point_atom_indices = point_atom_indices
-        
-        #check that amount of surface points equals the no. of point-to-atom indices 
-        assert len(self.surface_points) == len(self.point_atom_indices), \
-        f"Mismatch! Created {len(self.surface_points)} surface points " \
-        f"but generated {len(self.point_atom_indices)} point-to-atom indices"
-
-
-
+ 
+        assert len(self.surface_points) == len(self.point_atom_indices), (
+            f"Mismatch! Created {len(self.surface_points)} surface points "
+            f"but generated {len(self.point_atom_indices)} point-to-atom indices"
+        )
+ 
     def molecular_orbital_amplitude_per_point(self):
-        
+        """
+        Compute the amplitude of every occupied and unoccupied molecular
+        orbital at each surface point, storing them in
+        self.occ_mo_points_amplitude / self.unocc_mo_points_amplitude.
+        """
         chi_g = self.compute_gto_values_at_custom_points(self.molgrid)
         mol_orb_coeff = self.scf_results["C_alpha"]
-
-        occ_orb = sum(self.scf_results['occ_alpha'])   
-        tot_orb = len(self.scf_results['occ_alpha'])
-
-        for i in range(int(occ_orb)):                              #for occupied orbitals
-            mo_val = np.dot(chi_g.T, mol_orb_coeff[:, i])   # Atomic orbitals amplitude (per point in gid) * Coeffients for linnearily combining AO into MO = MO amplitude in each point
+        occ_orb = sum(self.scf_results["occ_alpha"])
+        tot_orb = len(self.scf_results["occ_alpha"])
+ 
+        for i in range(int(occ_orb)):
+            mo_val = np.dot(chi_g.T, mol_orb_coeff[:, i])
             self.occ_mo_points_amplitude.append(mo_val)
-
-        for i in range(int(occ_orb), int(tot_orb)):                     #same
+ 
+        for i in range(int(occ_orb), int(tot_orb)):
             mo_val = np.dot(chi_g.T, mol_orb_coeff[:, i])
             self.unocc_mo_points_amplitude.append(mo_val)
-                
-
+ 
     def compute_IE_and_EA(self):
-        energy_occ = self.scf_results['E_alpha'][:int(sum(self.scf_results['occ_alpha']))]    # Energies (Hartree) of occupied alpha MOs as calculated by scfdrver    
-        energy_unocc = self.scf_results['E_alpha'][int(sum(self.scf_results['occ_alpha'])):] # Energies (Hartree) of virtual (empty) alpha MOs as calculated by scfdrver
-         
-        for idx, point in enumerate(self.surface_points):     #loop over all the surface points, keeping idx to find the correct surface point for every MO in "self.unocc_mo_points_amplitude"
-            
-            ea_point_numerator, ea_point_denominator  = 0, 0 # Initialize 
-
-            for j in range(len(self.unocc_mo_points_amplitude)):  #Loop over  all unoccupied MOs; LUMO, LUMO+1, etc and their amplitude in every point [[MO1: p1, p2 ... pn], [MO2 p1, p2 ... pn]]
-
-                unocc_mo_ampl_squared = (self.unocc_mo_points_amplitude[j][idx])**2         #squared cumulative amplitude for LUMO1 point1, LUMO2 point 1, LUMO3 point1 until LUMOn, point n
-
-                ea_point_numerator += (unocc_mo_ampl_squared * energy_unocc[j])        #sum of squared amplitudes x virtual orbital energy
-                ea_point_denominator += unocc_mo_ampl_squared                          #sum of squared amplitudes
-
-            ea = (-ea_point_numerator / ea_point_denominator )* 27.211407953              #Hartree to eV
-            self.ea_values.append(ea)  
-
-
-            ie_point_numerator, ie_point_denominator  = 0, 0 # Initialize 
-
-            for j in range(len(self.occ_mo_points_amplitude)):  #Loop over  all occupied MOs and their amplitude in every point [[MO1: p1, p2 ... pn], [MO2 p1, p2 ... pn]]
-
-                occ_mo_ampl_squared = (self.occ_mo_points_amplitude[j][idx])**2         #squared cumulative amplitude 
-
-                ie_point_numerator += (occ_mo_ampl_squared * abs(energy_occ[j]))        #sum of squared amplitudes x orbital energy
-                ie_point_denominator += occ_mo_ampl_squared                          #sum of squared amplitudes
-
-                 
-            ie = (ie_point_numerator/ie_point_denominator)* 27.211407953            #Hartree to eV
+        """
+        Compute local surface ionization energy (IE) and electron affinity
+        (EA) at each surface point, in eV, from the amplitude-weighted
+        average of orbital energies (analogous to the average local
+        ionization energy formalism). Results are stored in self.ie_values
+        and self.ea_values, one entry per surface point.
+        """
+        n_occ = int(sum(self.scf_results["occ_alpha"]))
+        energy_occ = self.scf_results["E_alpha"][:n_occ]      # Hartree
+        energy_unocc = self.scf_results["E_alpha"][n_occ:]    # Hartree
+ 
+        for idx, _point in enumerate(self.surface_points):
+            ea_numerator, ea_denominator = 0.0, 0.0
+            for j in range(len(self.unocc_mo_points_amplitude)):
+                amp_sq = self.unocc_mo_points_amplitude[j][idx] ** 2
+                ea_numerator += amp_sq * energy_unocc[j]
+                ea_denominator += amp_sq
+            ea = (-ea_numerator / ea_denominator) * HARTREE_TO_EV
+            self.ea_values.append(ea)
+ 
+            ie_numerator, ie_denominator = 0.0, 0.0
+            for j in range(len(self.occ_mo_points_amplitude)):
+                amp_sq = self.occ_mo_points_amplitude[j][idx] ** 2
+                ie_numerator += amp_sq * abs(energy_occ[j])
+                ie_denominator += amp_sq
+            ie = (ie_numerator / ie_denominator) * HARTREE_TO_EV
             self.ie_values.append(ie)
-
-        print(f'{len(self.ea_values)}, {len(self.ie_values)} values of electron affinity and ionization energy calculated for {len(self.surface_points)} surface points ')
-
-
-
-
+ 
+        print(
+            f"{len(self.ea_values)}, {len(self.ie_values)} values of electron "
+            f"affinity and ionization energy calculated for "
+            f"{len(self.surface_points)} surface points"
+        )
+ 
     def compute_atom_statistics(self):
-
-        # Create point-level data
+        """
+        Aggregate per-point IE/EA values into per-atom statistics
+        (min/max/mean/std/n_points), stored in self.ea_ie_results, keyed by
+        atom index.
+        """
         point_data = []
         for i in range(len(self.surface_points)):
             point_data.append({
-                'point_index': i + 1,
-                'atom_label': self.molecule.get_label(self.point_atom_indices[i]),
-                'atom_index': int(self.point_atom_indices[i]),
-                'IE': self.ie_values[i],
-                'EA': self.ea_values[i]
+                "point_index": i + 1,
+                "atom_label": self.molecule.get_label(self.point_atom_indices[i]),
+                "atom_index": int(self.point_atom_indices[i]),
+                "IE": self.ie_values[i],
+                "EA": self.ea_values[i],
             })
-        
-        # Group by atom for statistics
+ 
         ea_data = defaultdict(list)
         ie_data = defaultdict(list)
-        
         for point in point_data:
-            atom_idx = point['atom_index']
-            ea_data[atom_idx].append(point['EA'])
-            ie_data[atom_idx].append(point['IE'])
-        
-        # Calculate per-atom statistics
+            atom_idx = point["atom_index"]
+            ea_data[atom_idx].append(point["EA"])
+            ie_data[atom_idx].append(point["IE"])
+ 
         atom_statistics = {}
-        
         for atom in range(len(self.molecule.get_labels())):
-            print(f'Atom : {atom}')
             if not ea_data[atom] or not ie_data[atom]:
                 atom_statistics[atom] = {
-                    'min_EA': np.nan,
-                    'max_EA': np.nan,
-                    'mean_EA': np.nan,
-                    'std_EA': np.nan,
-                    'n_points': 0,
-                    'min_IE': np.nan,
-                    'max_IE': np.nan,
-                    'mean_IE': np.nan,
-                    'std_IE': np.nan
+                    "min_EA": np.nan, "max_EA": np.nan, "mean_EA": np.nan, "std_EA": np.nan,
+                    "n_points": 0,
+                    "min_IE": np.nan, "max_IE": np.nan, "mean_IE": np.nan, "std_IE": np.nan,
                 }
                 continue
             atom_statistics[atom] = {
-                'min_EA': min(ea_data[atom]),
-                'max_EA': max(ea_data[atom]),
-                'mean_EA': np.mean(ea_data[atom]),
-                'std_EA': np.std(ea_data[atom]),
-                'n_points': len(ea_data[atom]),
-                'min_IE': min(ie_data[atom]),
-                'max_IE': max(ie_data[atom]),
-                'mean_IE': np.mean(ie_data[atom]),
-                'std_IE': np.std(ie_data[atom])
+                "min_EA": min(ea_data[atom]),
+                "max_EA": max(ea_data[atom]),
+                "mean_EA": np.mean(ea_data[atom]),
+                "std_EA": np.std(ea_data[atom]),
+                "n_points": len(ea_data[atom]),
+                "min_IE": min(ie_data[atom]),
+                "max_IE": max(ie_data[atom]),
+                "mean_IE": np.mean(ie_data[atom]),
+                "std_IE": np.std(ie_data[atom]),
             }
-        
-        # Store in self.results
+ 
         self.ea_ie_results = atom_statistics
-        
-        
-
-        
-    def define_atom_types(self):                           #Uses AtomTypeIdentifier to categorize each atom according to GAFF
+ 
+    def define_atom_types(self):
+        """Assign a GAFF atom type to every atom via vlx.AtomTypeIdentifier."""
         atomtypeidentifier = vlx.AtomTypeIdentifier()
         self.atomtypes = atomtypeidentifier.generate_gaff_atomtypes(self.molecule)
-
-
-
-
-    def compute_log_p_and_SASA(self): 
-    
-
-        #SASA calculation
+ 
+    def compute_log_p_and_SASA(self):
+        """
+        Estimate logP from the water/1-octanol SMD solvation free-energy
+        difference, and compute total SASA (Å^2).
+ 
+        Runs two additional SCF calculations (water, 1-octanol solvation)
+        at self.logp_basis_label / self.logp_xcfun, independent of the
+        basis/driver used for the main descriptor calculation — see the
+        note on those attributes in __init__.
+        """
         smd = vlx.SmdDriver()
         smd.solute = self.molecule
         sasa_list = smd._get_SASA()
-        self.sasa = sum(sasa_list) # Å^2
-
-        #Calc scf energy for water solvation
-        basis = vlx.MolecularBasis.read(self.molecule, 'def2-svp')
-
-        scf_drv = vlx.ScfRestrictedDriver()
-        scf_drv.xcfun = 'b3lyp'
-        scf_drv.solvation_model = 'smd'
-        scf_drv.smd_solvent = 'water'
-
-        scf_results_water = scf_drv.compute(self.molecule, basis)
-
-        #Calc scf energy for octanol solvation
-        basis = vlx.MolecularBasis.read(self.molecule, 'def2-svp')
-
-        scf_drv = vlx.ScfRestrictedDriver()
-        scf_drv.xcfun = 'b3lyp'
-        scf_drv.solvation_model = 'smd'
-        scf_drv.smd_solvent = '1-octanol'
-
-        scf_results_octanol = scf_drv.compute(self.molecule, basis)
-        
-
-        #calculate log p
-        hartree_to_j_mol = 2625500.2
-        R = 8.3144626  # J / (mol * K)
-        T = 298.15     # Kelvin
-
+        self.sasa = sum(sasa_list)  # Å^2
  
-        ddg_solv_hartree  = scf_results_octanol['scf_energy'] - scf_results_water['scf_energy']
-        ddg_solv_j_mol = ddg_solv_hartree * hartree_to_j_mol
-
-        self.log_p = -ddg_solv_j_mol / (np.log(10) * R * T)
-
-
-
+        logp_basis = vlx.MolecularBasis.read(self.molecule, self.logp_basis_label)
+ 
+        scf_drv = vlx.ScfRestrictedDriver()
+        scf_drv.xcfun = self.logp_xcfun
+        scf_drv.solvation_model = "smd"
+        scf_drv.smd_solvent = "water"
+        scf_results_water = scf_drv.compute(self.molecule, logp_basis)
+ 
+        scf_drv = vlx.ScfRestrictedDriver()
+        scf_drv.xcfun = self.logp_xcfun
+        scf_drv.solvation_model = "smd"
+        scf_drv.smd_solvent = "1-octanol"
+        scf_results_octanol = scf_drv.compute(self.molecule, logp_basis)
+ 
+        ddg_solv_hartree = scf_results_octanol["scf_energy"] - scf_results_water["scf_energy"]
+        ddg_solv_j_mol = ddg_solv_hartree * HARTREE_TO_J_PER_MOL
+        self.log_p = -ddg_solv_j_mol / (
+            np.log(10) * GAS_CONSTANT_J_PER_MOL_K * ROOM_TEMPERATURE_K
+        )
+ 
     def compile_results(self):
-        
-        self.results_dict['IE_EA'] = self.ea_ie_results
-        self.results_dict['atomtypes'] = self.atomtypes
-        self.results_dict['log_p'] = self.log_p
-        self.results_dict['sasa'] = self.sasa
-        self.results_dict['RESP_charges'] = self.resp_charges
-        self.results_dict['ie_surface_average'] = np.mean(self.ie_values)
-        self.results_dict['ea_surface_average'] = np.mean(self.ea_values)
-        self.results_dict['scf_results'] = self.scf_results
-
-
-        
-
-
-
-
-
-
-
-
-
-    def compute_descriptors(self, molecule, basis=None, scf_drv=None, scf_results = None):
+        """Assemble every computed descriptor into self.results_dict."""
+        self.results_dict["IE_EA"] = self.ea_ie_results
+        self.results_dict["atomtypes"] = self.atomtypes
+        self.results_dict["log_p"] = self.log_p
+        self.results_dict["sasa"] = self.sasa
+        self.results_dict["RESP_charges"] = self.resp_charges
+        self.results_dict["ie_surface_average"] = np.mean(self.ie_values)
+        self.results_dict["ea_surface_average"] = np.mean(self.ea_values)
+        self.results_dict["scf_results"] = self.scf_results
+ 
+    def compute_descriptors(
+        self,
+        molecule: "vlx.Molecule",
+        basis: Optional["vlx.MolecularBasis"] = None,
+        scf_drv: Optional["vlx.ScfRestrictedDriver"] = None,
+        scf_results: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Compute the full set of descriptors for `molecule` and return them
+        as a dict.
+ 
+        Parameters
+        ----------
+        molecule
+            Molecule to compute descriptors for.
+        basis
+            Basis set to use for the SCF/surface calculations. Defaults to
+            def2-svpd if not provided.
+        scf_drv
+            SCF driver to use. Defaults to a restricted B3LYP driver if not
+            provided.
+        scf_results
+            Pre-computed SCF results for molecule/basis/scf_drv, to avoid
+            recomputation if already available.
+ 
+        Returns
+        -------
+        dict
+            See compile_results() for the keys included.
+        """
         self.molecule = molecule
-
-
-        # Create basis if not provided
+ 
         if basis is None:
-            basis = vlx.MolecularBasis.read(molecule, 'def2-svpd')
+            basis = vlx.MolecularBasis.read(molecule, "def2-svpd")
         self.basis = basis
-    
-        # instantiate SCF driver if not provided  
+ 
         if scf_drv is None:
             scf_drv = vlx.ScfRestrictedDriver()
-            scf_drv.xcfun = 'b3lyp'
+            scf_drv.xcfun = "b3lyp"
         self.scf_drv = scf_drv
-        
+ 
         if scf_results is None:
-            scf_results = scf_drv.compute(self.molecule, self.basis)  #electronic structure needed to find surface grid
+            scf_results = scf_drv.compute(self.molecule, self.basis)
         self.scf_results = scf_results
  
-      
-        # Compute RESP charges for all geometries
-        print(f"computing RESP-charges...")
-        self.compute_respcharges()    
-
-        #compute surface points for molecule
-        print(f"Creating surface grid...")
+        print("computing RESP-charges...")
+        self.compute_respcharges()
+ 
+        print("Creating surface grid...")
         self.create_surface_points()
-        
-        #assign each point to closest atom
-        print(f"Assigning grid points to atoms...")
+ 
+        print("Assigning grid points to atoms...")
         self.assign_points_to_atoms()
-
-        #calculate molecular orbital amplitude at each point
-        print(f"Computing atomic IE and EA enegies...")
+ 
+        print("Computing atomic IE and EA energies...")
         self.molecular_orbital_amplitude_per_point()
-
-        self.compute_IE_and_EA()    #eV
-
-        # Compute atom statistics and store in self.results
-        
+        self.compute_IE_and_EA()
+ 
         self.compute_atom_statistics()
-
-
-
-        # Define atomtypes in molecule
         self.define_atom_types()
-
-
-       # self.compute_log_p_and_SASA()
-        self.compute_log_p_and_SASA() 
+        self.compute_log_p_and_SASA()
+ 
         self.compile_results()
-
-
         return self.results_dict
+
+

--- a/src/pymodule/descriptordriver.py
+++ b/src/pymodule/descriptordriver.py
@@ -1,10 +1,14 @@
 """Driver for computing atom- and molecule-level QM/empirical descriptors."""
  
+from pathlib import Path
 from collections import defaultdict
 from typing import Any, Dict, Optional
  
 import numpy as np
 import veloxchem as vlx
+
+from .resultsio import (read_descriptor_results,
+                        write_descriptor_results_to_hdf5)
  
  
 # Unit conversion / physical constants used below.
@@ -32,6 +36,7 @@ class DescriptorDriver:
     """
  
     def __init__(self):
+        self.filename = None
         self.molecule = None       # molecule for descriptor calculation
         self.basis = None
         self.scf_drv = None
@@ -295,6 +300,65 @@ class DescriptorDriver:
         self.results_dict["ie_surface_average"] = np.mean(self.ie_values)
         self.results_dict["ea_surface_average"] = np.mean(self.ea_values)
         self.results_dict["scf_results"] = self.scf_results
+
+    def _get_hdf5_results(self, results: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Convert descriptor results to a compact HDF5 payload.
+
+        The full SCF result dictionary is intentionally omitted because SCF
+        data should already be stored under the scf group in shared files.
+        """
+
+        xcfun = getattr(self.scf_drv, "xcfun", None)
+        if xcfun is None:
+            main_xcfun = None
+        elif isinstance(xcfun, str):
+            main_xcfun = xcfun
+        else:
+            main_xcfun = xcfun.get_func_label()
+
+        return {
+            "descriptor_schema_version": 1,
+            "summary": {
+                "log_p": results["log_p"],
+                "sasa": results["sasa"],
+                "ie_surface_average": results["ie_surface_average"],
+                "ea_surface_average": results["ea_surface_average"],
+            },
+            "per_atom": results["IE_EA"],
+            "atomtypes": results["atomtypes"],
+            "resp_charges": results["RESP_charges"],
+            "provenance": {
+                "main_basis_label": self.basis.get_label(),
+                "main_xcfun": main_xcfun,
+                "resp_basis_label": self.resp_basis_label,
+                "logp_basis_label": self.logp_basis_label,
+                "logp_xcfun": self.logp_xcfun,
+            },
+        }
+
+    def _write_final_hdf5(self, fname: str, results: Dict[str, Any]):
+        """
+        Write descriptor results to an HDF5 file.
+
+        If the target file does not exist, create an empty file first and then
+        write/replace the descriptor group.
+        """
+
+        if not fname:
+            return
+
+        fpath = Path(fname).with_suffix(".h5")
+        fpath.touch(exist_ok=True)
+
+        write_descriptor_results_to_hdf5(str(fpath),
+                                         self._get_hdf5_results(results))
+
+    @staticmethod
+    def read_hdf5(fname: str) -> Dict[str, Any]:
+        """Read descriptor results from an HDF5 file."""
+
+        return read_descriptor_results(str(Path(fname).with_suffix(".h5")))
  
     def compute_descriptors(
         self,
@@ -327,6 +391,22 @@ class DescriptorDriver:
             See compile_results() for the keys included.
         """
         self.molecule = molecule
+
+        # Reset transient state so repeated calls on the same driver instance
+        # do not accumulate point/orbital arrays from previous runs.
+        self.molgrid = None
+        self.surface_points = None
+        self.point_atom_indices = None
+        self.occ_mo_points_amplitude = []
+        self.unocc_mo_points_amplitude = []
+        self.ea_values = []
+        self.ie_values = []
+        self.atomtypes = []
+        self.sasa = None
+        self.log_p = None
+        self.resp_charges = None
+        self.ea_ie_results = None
+        self.results_dict = {}
  
         if basis is None:
             basis = vlx.MolecularBasis.read(molecule, "def2-svpd")
@@ -359,6 +439,10 @@ class DescriptorDriver:
         self.compute_log_p_and_SASA()
  
         self.compile_results()
+
+        if self.filename is not None:
+            self._write_final_hdf5(self.filename, self.results_dict)
+
         return self.results_dict
 
 

--- a/src/pymodule/resultsio.py
+++ b/src/pymodule/resultsio.py
@@ -448,6 +448,22 @@ def write_lr_rsp_results_to_hdf5(fname, rsp_results):
                           replace_group=False)
 
 
+def write_descriptor_results_to_hdf5(fname, descriptor_results):
+    """
+    Writes descriptor results to HDF5 file.
+
+    :param fname:
+        Name of the HDF5 file.
+    :param descriptor_results:
+        The dictionary containing descriptor results.
+    """
+
+    write_results_to_hdf5(fname,
+                          'descriptor',
+                          descriptor_results,
+                          value_label='descriptor result')
+
+
 def write_detach_attach_to_hdf5(fname,
                                 state_label,
                                 dens_detach,
@@ -534,6 +550,20 @@ def read_results(fname, label):
                             label + " section not found in the checkpoint file.")
 
         return _read_value_from_hdf5(h5f[label], value_label='results')
+
+
+def read_descriptor_results(fname):
+    """
+    Read descriptor results from an HDF5 file.
+
+    :param fname:
+        Name of the HDF5 file.
+
+    :return:
+        The descriptor results dictionary.
+    """
+
+    return read_results(fname, 'descriptor')
 
 
 def read_molecule_and_basis(fname):

--- a/tests/test_resultsio.py
+++ b/tests/test_resultsio.py
@@ -8,9 +8,12 @@ import pytest
 from veloxchem import (Molecule, MolecularBasis, OptimizationDriver, MpiTask,
                        OutputStream, ScfGradientDriver, ScfRestrictedDriver,
                        mpi_master)
+from veloxchem.descriptordriver import DescriptorDriver
 from veloxchem.cppsolver import ComplexResponseSolver
 from veloxchem.lreigensolver import LinearResponseEigenSolver
-from veloxchem.resultsio import (read_results, write_results_to_hdf5,
+from veloxchem.resultsio import (read_descriptor_results, read_results,
+                                 write_descriptor_results_to_hdf5,
+                                 write_results_to_hdf5,
                                  write_scf_results_to_hdf5)
 from veloxchem.tdaeigensolver import TdaEigenSolver
 from veloxchem.vibrationalanalysis import VibrationalAnalysis
@@ -325,6 +328,116 @@ def test_read_results_roundtrips_only_requested_group(tmp_path):
     assert isinstance(recovered['F'], tuple)
     np.testing.assert_allclose(recovered['F'][0], scf_results['F'][0])
     np.testing.assert_allclose(recovered['F'][1], scf_results['F'][1])
+
+
+def test_descriptor_results_hdf5_roundtrip_and_group_isolation(tmp_path):
+
+    if MPI.COMM_WORLD.Get_rank() != mpi_master():
+        return
+
+    class _DummyBasis:
+
+        @staticmethod
+        def get_label():
+            return 'def2-svpd'
+
+    class _DummyScfDrv:
+        xcfun = 'b3lyp'
+
+    h5file = Path(tmp_path) / 'descriptor_results.h5'
+    with h5py.File(h5file, 'w') as h5f:
+        scf_group = h5f.create_group('scf')
+        scf_group.attrs['value_type'] = 'dict'
+        scf_group.attrs['dict_storage'] = 'named'
+        energy = scf_group.create_dataset('scf_energy', data=-75.0)
+        energy.attrs['value_type'] = 'float'
+
+    descriptor_results = {
+        'IE_EA': {
+            0: {
+                'min_EA': 0.1,
+                'max_EA': 0.2,
+                'mean_EA': 0.15,
+                'std_EA': 0.01,
+                'n_points': 5,
+                'min_IE': 12.0,
+                'max_IE': 13.0,
+                'mean_IE': 12.5,
+                'std_IE': 0.2,
+            },
+            1: {
+                'min_EA': 0.3,
+                'max_EA': 0.4,
+                'mean_EA': 0.35,
+                'std_EA': 0.01,
+                'n_points': 6,
+                'min_IE': 11.0,
+                'max_IE': 12.0,
+                'mean_IE': 11.5,
+                'std_IE': 0.2,
+            },
+        },
+        'atomtypes': ['oh', 'ho'],
+        'log_p': -1.2,
+        'sasa': 33.4,
+        'RESP_charges': np.array([-0.8, 0.4, 0.4]),
+        'ie_surface_average': 12.1,
+        'ea_surface_average': 0.21,
+        'scf_results': {
+            'scf_energy': -75.0,
+        },
+    }
+
+    drv = DescriptorDriver()
+    drv.basis = _DummyBasis()
+    drv.scf_drv = _DummyScfDrv()
+    drv._write_final_hdf5(str(h5file), descriptor_results)
+
+    expected = drv._get_hdf5_results(descriptor_results)
+    recovered = read_descriptor_results(str(h5file))
+
+    _assert_roundtrip_equal(expected, recovered)
+
+    with h5py.File(h5file, 'r') as h5f:
+        assert 'scf' in h5f
+        assert h5f['scf/scf_energy'][()] == pytest.approx(-75.0)
+
+
+def test_write_descriptor_results_to_hdf5_writes_descriptor_group(tmp_path):
+
+    if MPI.COMM_WORLD.Get_rank() != mpi_master():
+        return
+
+    h5file = Path(tmp_path) / 'descriptor_group_only.h5'
+    with h5py.File(h5file, 'w'):
+        pass
+
+    descriptor_payload = {
+        'descriptor_schema_version': 1,
+        'summary': {
+            'log_p': -0.7,
+            'sasa': 25.0,
+            'ie_surface_average': 10.1,
+            'ea_surface_average': 0.9,
+        },
+        'per_atom': {
+            0: {'n_points': 10},
+        },
+        'atomtypes': ['c3'],
+        'resp_charges': np.array([0.0]),
+        'provenance': {
+            'main_basis_label': 'def2-svpd',
+            'main_xcfun': 'b3lyp',
+            'resp_basis_label': '6-31G*',
+            'logp_basis_label': 'def2-svp',
+            'logp_xcfun': 'b3lyp',
+        },
+    }
+
+    write_descriptor_results_to_hdf5(str(h5file), descriptor_payload)
+    recovered = read_descriptor_results(str(h5file))
+
+    _assert_roundtrip_equal(descriptor_payload, recovered)
 
 
 def test_read_results_roundtrips_tda_rsp_and_preserves_legacy_solution_vectors(


### PR DESCRIPTION
## Summary
Adds `DescriptorDriver`, which computes a set of atom- and molecule-level descriptors from a converged SCF calculation.

## What's included
- RESP atomic partial charges (`compute_respcharges`)
- A CPCM-based molecular surface grid, with GTO evaluation at arbitrary 
  points via a work-around for `XCIntegrator` (`create_surface_points`, 
  `compute_gto_values_at_custom_points`)
- Assignment of surface points to their nearest atom, using van der 
  Waals-radius-adjusted distances (`assign_points_to_atoms`)
- Local surface ionization energy (IE) and electron affinity (EA) maps, 
  computed from MO-amplitude-weighted orbital energies at each surface 
  point (`molecular_orbital_amplitude_per_point`, `compute_IE_and_EA`)
- Per-atom IE/EA statistics (min/max/mean/std) aggregated over the 
  surface points nearest each atom (`compute_atom_statistics`)
- GAFF atom typing via `AtomTypeIdentifier` (`define_atom_types`)
- logP estimated from the SMD water/1-octanol solvation free-energy 
  difference, plus total SASA (`compute_log_p_and_SASA`)

Everything is orchestrated by 
`compute_descriptors(molecule, basis=None, scf_drv=None, scf_results=None)`, 
which returns a single `results_dict`. Also exports `DescriptorDriver` 
from the package `__init__.py`.

## Usage
```python
import veloxchem as vlx


molecule = vlx.Molecule.read_smiles("CCO")
driver = vlx.DescriptorDriver()
results = driver.compute_descriptors(molecule)

results["IE_EA"]        # per-atom IE/EA statistics
results["atomtypes"]    # GAFF atom types
results["log_p"]        # estimated logP
results["sasa"]         # total SASA (Å²)
results["RESP_charges"] # RESP charges
```

## Notes / open items
- logP/SASA step reruns two full SCF calculations (water, 1-octanol) at 
  a hardcoded def2-svp/b3lyp, independent of whatever basis/functional 
  was used for the main calculation — flagging this as a known 
  simplification.
