### PR TITLE
cleans up the TPA user-facing API

### DIFF
--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -674,12 +674,19 @@ def plot_tpa_spectrum(spectrum, ax=None, interpolate=True, show_points=True):
     if interpolate and len(x_data) >= 3:
         try:
             from scipy.interpolate import CubicSpline
-            x_dense = np.linspace(float(np.min(x_data)), float(np.max(x_data)),
-                                  500)
-            cs = CubicSpline(x_data, y_data)
+        except ImportError:
+            CubicSpline = None
+
+        if CubicSpline is not None:
+            sort_idx = np.argsort(x_data)
+            x_sorted = x_data[sort_idx]
+            y_sorted = y_data[sort_idx]
+            x_dense = np.linspace(float(np.min(x_sorted)),
+                                  float(np.max(x_sorted)), 500)
+            cs = CubicSpline(x_sorted, y_sorted)
             ax.plot(x_dense, cs(x_dense),
                     color='black', alpha=0.9, linewidth=2.5)
-        except ImportError:
+        else:
             ax.plot(x_data, y_data, color='black', alpha=0.9, linewidth=2.0)
     else:
         ax.plot(x_data, y_data, color='black', alpha=0.9, linewidth=2.0)

--- a/src/pymodule/tpadriverbase.py
+++ b/src/pymodule/tpadriverbase.py
@@ -458,7 +458,7 @@ class TpaDriverBase(NonlinearSolver):
                 'cross_sections': list(tpa_spectrum['y_data'])
             })
 
-            self.print_results(ret_dict, sections='all')
+            self.print_results(ret_dict, section='all')
 
         profiler.check_memory_usage('End of TPA')
 
@@ -877,39 +877,6 @@ class TpaDriverBase(NonlinearSolver):
 
         return 'TPA result'
 
-    @staticmethod
-    def _get_hdf5_results(results):
-        """
-        Converts gamma-based TPA results to a readable HDF5 payload.
-
-        :param results:
-            The results dictionary returned by compute().
-
-        :return:
-            A dictionary suitable for HDF5 serialization.
-        """
-
-        frequencies = [float(w) for w in results['frequencies'] if w != 0.0]
-        cross_sections = [float(val) for val in results['cross_sections']]
-        gamma = results['gamma']
-
-        spectrum_points = []
-        for w, cross_section in zip(frequencies, cross_sections):
-            gamma_value = gamma[(w, -w, w)]
-            spectrum_points.append({
-                'photon_energy_au': w,
-                'photon_energy_ev': float(w * hartree_in_ev()),
-                'gamma_real': float(gamma_value.real),
-                'gamma_imag': float(gamma_value.imag),
-                'cross_section_gm': cross_section,
-            })
-
-        return {
-            'frequencies_au': frequencies,
-            'cross_sections_gm': cross_sections,
-            'spectrum_points': spectrum_points,
-        }
-
     def _write_final_hdf5(self, fname, results):
         """
         Writes gamma-based TPA results to the specified HDF5 file.
@@ -921,18 +888,18 @@ class TpaDriverBase(NonlinearSolver):
         """
 
         if not fname:
-            raise ValueError('No filename given to _write_final_hdf5()')
+            return
 
         fpath = Path(fname)
         if fpath.suffix != '.h5':
             fpath = fpath.with_suffix('.h5')
 
         if not fpath.is_file():
-            raise ValueError(f'TPA HDF5 file does not exist: {fpath}')
+            return
 
         write_results_to_hdf5(str(fpath),
                               self._get_hdf5_group_name(),
-                              self._get_hdf5_results(results),
+                              results,
                               value_label=self._get_hdf5_value_label())
 
     def _get_summary_title(self):
@@ -967,41 +934,6 @@ class TpaDriverBase(NonlinearSolver):
         title += 'J. Chem. Phys. 154, 024111 (2021)'
         self.ostream.print_header(title.ljust(width))
         self.ostream.print_blank()
-
-    def _normalize_print_sections(self, sections):
-        """
-        Normalize requested print sections for gamma-based TPA results.
-
-        :param sections:
-            Section label or sequence of section labels.
-
-        :return:
-            Ordered list of normalized section labels.
-        """
-
-        valid_sections = ('summary', 'gamma', 'reference', 'spectrum', 'all')
-
-        if isinstance(sections, str):
-            requested_sections = [sections.lower()]
-        else:
-            requested_sections = [section.lower() for section in sections]
-
-        invalid_sections = [
-            section for section in requested_sections if section not in valid_sections
-        ]
-        assert_msg_critical(
-            not invalid_sections,
-            'TpaDriverBase.print_results: Invalid section label(s).')
-
-        if 'all' in requested_sections:
-            requested_sections = ['gamma', 'reference', 'spectrum']
-
-        normalized_sections = []
-        for section in requested_sections:
-            if section not in normalized_sections:
-                normalized_sections.append(section)
-
-        return normalized_sections
 
     def _print_summary(self, rsp_results):
         """
@@ -1087,46 +1019,38 @@ class TpaDriverBase(NonlinearSolver):
         spectrum = self.get_spectrum(rsp_results, x_unit='au')
         self._print_spectrum(spectrum, width)
 
-    def _print_results(self, rsp_results, sections='all'):
-        """
-        Prints the selected sections of gamma-based TPA results.
-
-        :param rsp_results:
-            A dictionary containing the results of response calculation.
-        :param sections:
-            The sections to print.
-        """
-
-        for section in self._normalize_print_sections(sections):
-            if section == 'summary':
-                self._print_summary(rsp_results)
-            elif section == 'gamma':
-                self._print_note()
-                self._print_gamma(rsp_results)
-            elif section == 'reference':
-                width = len('{:<8s}{:>14s}{:>21s}{:>22s}'.format(
-                    '', 'Photon Energy', 'Real', 'Imaginary'))
-                self._print_reference(width)
-            elif section == 'spectrum':
-                self._print_spectrum_section(rsp_results)
-
-        self.ostream.print_blank()
-        self.ostream.flush()
-
-    def print_results(self, rsp_results, sections='all'):
+    def print_results(self, rsp_results, section='all'):
         """
         Prints the selected sections of TPA results.
 
         :param rsp_results:
             A dictionary containing the results of response calculation.
-        :param sections:
-            Section label or sequence of section labels.
+        :param section:
+            Section label.
         """
 
-        if self.rank != mpi_master():
-            return
+        section = section.lower()
+        assert_msg_critical(
+            section in ['summary', 'gamma', 'reference', 'spectrum', 'all'],
+            'TpaDriverBase.print_results: Invalid section label.')
 
-        self._print_results(rsp_results, sections=sections)
+        if section == 'summary':
+            self._print_summary(rsp_results)
+
+        if section in ['gamma', 'all']:
+            self._print_gamma(rsp_results)
+            self._print_note()
+
+        if section in ['reference', 'all']:
+            width = len('{:<8s}{:>14s}{:>21s}{:>22s}'.format(
+                '', 'Photon Energy', 'Real', 'Imaginary'))
+            self._print_reference(width)
+
+        if section in ['spectrum', 'all']:
+            self._print_spectrum_section(rsp_results)
+
+        self.ostream.print_blank()
+        self.ostream.flush()
 
     def plot_spectrum(self,
                       rsp_results,

--- a/src/pymodule/tpareddriver.py
+++ b/src/pymodule/tpareddriver.py
@@ -994,42 +994,6 @@ class TpaReducedDriver(TpaDriverBase):
 
         return None
 
-    def _normalize_print_sections(self, sections):
-        """
-        Normalize requested print sections for reduced TPA results.
-
-        :param sections:
-            Section label or sequence of section labels.
-
-        :return:
-            Ordered list of normalized section labels.
-        """
-
-        if isinstance(sections, str):
-            requested_sections = [sections.lower()]
-        else:
-            requested_sections = [section.lower() for section in sections]
-
-        valid_sections = ('summary', 'note', 'gamma', 'reference', 'spectrum',
-                          'all')
-        invalid_sections = [
-            section for section in requested_sections if section not in valid_sections
-        ]
-        from .errorhandler import assert_msg_critical
-        assert_msg_critical(
-            not invalid_sections,
-            'TpaReducedDriver.print_results: Invalid section label(s).')
-
-        if 'all' in requested_sections:
-            requested_sections = ['note', 'gamma', 'reference', 'spectrum']
-
-        normalized_sections = []
-        for section in requested_sections:
-            if section not in normalized_sections:
-                normalized_sections.append(section)
-
-        return normalized_sections
-
     def _get_summary_title(self):
         """
         Gets the summary-table title for reduced TPA results.
@@ -1042,10 +1006,8 @@ class TpaReducedDriver(TpaDriverBase):
 
     def _print_note(self):
         """
-        Prints the reduced TPA approximation note and reference.
+        Prints the reduced TPA approximation note.
         """
-
-        width = 68
 
         w_str = '*** Note: The reduced expression is an approximation to the  '
         self.ostream.print_header(w_str)
@@ -1053,13 +1015,5 @@ class TpaReducedDriver(TpaDriverBase):
         self.ostream.print_header(w_str)
         w_str = '    intended for use in one-photon off-resonance regions.    '
         self.ostream.print_header(w_str)
-        self.ostream.print_blank()
-
-        title = 'Reference: '
-        title += 'K. Ahmadzadeh, M. Scott, M. Brand, O. Vahtras, X. Li, '
-        self.ostream.print_header(title.ljust(width))
-        title = 'Z. Rinkevicius, and P. Norman, '
-        title += 'J. Chem. Phys. 154, 024111 (2021)'
-        self.ostream.print_header(title.ljust(width))
         self.ostream.print_blank()
 

--- a/src/pymodule/tpatransitiondriver.py
+++ b/src/pymodule/tpatransitiondriver.py
@@ -104,63 +104,6 @@ class TpaTransitionDriver(NonlinearSolver):
             'nstates': ('int', 'number of excited states'),
         })
 
-    @staticmethod
-    def _get_hdf5_results(results):
-        """
-        Converts TPA transition results to a readable HDF5 payload.
-
-        :param results:
-            The results dictionary returned by compute().
-
-        :return:
-            A dictionary suitable for HDF5 serialization.
-        """
-
-        def get_indexed_value(values, index):
-            if isinstance(values, dict):
-                return values[index]
-            return values[index]
-
-        states = []
-        photon_energies = results['photon_energies']
-
-        for state_index, energy_au in enumerate(photon_energies, start=1):
-            state_ind = state_index - 1
-            tensor = np.asarray(get_indexed_value(results['transition_moments'],
-                                                  state_ind))
-            dipole = np.asarray(get_indexed_value(results['elec_trans_dipoles'],
-                                                  state_ind))
-            exc_details = get_indexed_value(results['excitation_details'],
-                                            state_ind)
-
-            states.append({
-                'state_index': state_index,
-                'photon_energy_au': float(energy_au),
-                'photon_energy_ev': float(energy_au * hartree_in_ev()),
-                'transition_moment': {
-                    'Sxx': tensor[0, 0],
-                    'Syy': tensor[1, 1],
-                    'Szz': tensor[2, 2],
-                    'Sxy': tensor[0, 1],
-                    'Sxz': tensor[0, 2],
-                    'Syz': tensor[1, 2],
-                },
-                'tpa_strength_linear': get_indexed_value(
-                    results['tpa_strengths']['linear'], state_ind),
-                'tpa_strength_circular': get_indexed_value(
-                    results['tpa_strengths']['circular'], state_ind),
-                'oscillator_strength': get_indexed_value(
-                    results['oscillator_strengths'], state_ind),
-                'electric_transition_dipole': {
-                    'x': dipole[0],
-                    'y': dipole[1],
-                    'z': dipole[2],
-                },
-                'excitation_details': list(exc_details),
-            })
-
-        return {'states': states}
-
     def _write_final_hdf5(self, fname, results):
         """
         Writes TPA transition results to the specified HDF5 file.
@@ -172,18 +115,18 @@ class TpaTransitionDriver(NonlinearSolver):
         """
 
         if not fname:
-            raise ValueError('No filename given to _write_final_hdf5()')
+            return
 
         fpath = Path(fname)
         if fpath.suffix != '.h5':
             fpath = fpath.with_suffix('.h5')
 
         if not fpath.is_file():
-            raise ValueError(f'TPA transition HDF5 file does not exist: {fpath}')
+            return
 
         write_results_to_hdf5(str(fpath),
                               'tpa_transition',
-                              self._get_hdf5_results(results),
+                              results,
                               value_label='TPA transition result')
 
     def update_settings(self, rsp_dict, method_dict=None):
@@ -692,12 +635,6 @@ class TpaTransitionDriver(NonlinearSolver):
                 eigvals, eigvecs = np.linalg.eigh(tensor)
                 diagonalized_tensors[key] = np.diag(eigvals)
 
-        self.ostream.print_blank()
-        w_str = 'Summary of Two-photon Absorption'
-        self.ostream.print_header(w_str)
-        self.ostream.print_header('=' * (len(w_str) + 2))
-        self.ostream.print_blank()
-
         if self.rank == mpi_master():
             tpa_strengths = {'linear': {}, 'circular': {}}
 
@@ -1081,42 +1018,6 @@ class TpaTransitionDriver(NonlinearSolver):
             'z', value[2][0].real, value[2][1].real, value[2][2].real)
         self.ostream.print_header(w_str.ljust(width))
 
-    @staticmethod
-    def _normalize_print_sections(sections):
-        """
-        Normalize requested print sections for transition TPA results.
-
-        :param sections:
-            Section label or sequence of section labels.
-
-        :return:
-            Ordered list of normalized section labels.
-        """
-
-        valid_sections = ('summary', 'moments', 'strengths', 'all')
-
-        if isinstance(sections, str):
-            requested_sections = [sections.lower()]
-        else:
-            requested_sections = [section.lower() for section in sections]
-
-        invalid_sections = [
-            section for section in requested_sections if section not in valid_sections
-        ]
-        assert_msg_critical(
-            not invalid_sections,
-            'TpaTransitionDriver.print_results: Invalid section label(s).')
-
-        if 'all' in requested_sections:
-            requested_sections = ['moments', 'strengths']
-
-        normalized_sections = []
-        for section in requested_sections:
-            if section not in normalized_sections:
-                normalized_sections.append(section)
-
-        return normalized_sections
-
     def _print_summary(self, rsp_results, max_states=None):
         """
         Prints a compact summary of TPA transition results.
@@ -1252,46 +1153,40 @@ class TpaTransitionDriver(NonlinearSolver):
         self.ostream.print_blank()
         self.ostream.print_blank()
 
-    def _print_results(self, rsp_results, sections='all', max_states=None):
-        """
-        Prints the results of TPA calculation.
-
-        :param rsp_results:
-            A dictonary containing the results of response calculation.
-        :param sections:
-            The sections to print.
-        :param max_states:
-            Optional maximum number of states to print in summary mode.
-        """
-
-        for section in self._normalize_print_sections(sections):
-            if section == 'summary':
-                self._print_summary(rsp_results, max_states=max_states)
-            elif section == 'moments':
-                self._print_moments(rsp_results)
-            elif section == 'strengths':
-                self._print_strengths(rsp_results)
-
-        self.ostream.flush()
-
-    def print_results(self, rsp_results, sections='all', max_states=None):
+    def print_results(self, rsp_results, section='all', max_states=None):
         """
         Prints the results of TPA transition calculation.
 
         :param rsp_results:
             A dictionary containing the results of response calculation.
-        :param sections:
-            Section label or sequence of section labels.
+        :param section:
+            Section label.
         :param max_states:
             Optional maximum number of states to print in summary mode.
         """
 
-        if self.rank != mpi_master():
-            return
+        section = section.lower()
+        assert_msg_critical(
+            section in ['summary', 'moments', 'strengths', 'all'],
+            'TpaTransitionDriver.print_results: Invalid section label.')
 
-        self._print_results(rsp_results,
-                            sections=sections,
-                            max_states=max_states)
+        if section == 'summary':
+            self._print_summary(rsp_results, max_states=max_states)
+
+        if section in ['moments', 'strengths', 'all']:
+            self.ostream.print_blank()
+            title = 'Summary of Two-photon Absorption'
+            self.ostream.print_header(title)
+            self.ostream.print_header('=' * (len(title) + 2))
+            self.ostream.print_blank()
+
+        if section in ['moments', 'all']:
+            self._print_moments(rsp_results)
+
+        if section in ['strengths', 'all']:
+            self._print_strengths(rsp_results)
+
+        self.ostream.flush()
 
     def plot_spectrum(self,
                       rsp_results,
@@ -1357,7 +1252,8 @@ class TpaTransitionDriver(NonlinearSolver):
             x_data = np.linspace(xmin, xmax, 1000)
 
         spectrum = self.get_spectrum(rsp_results, x_data, x_unit,
-                                     broadening_value, broadening_unit)
+                         broadening_value, broadening_unit,
+                         polarization)
 
         plotted_ax = plot_tpa_transition_spectrum(rsp_results,
                               spectrum,
@@ -1369,7 +1265,8 @@ class TpaTransitionDriver(NonlinearSolver):
         return plotted_ax if ax is not None else None
 
     @staticmethod
-    def get_spectrum(rsp_results, x_data, x_unit, b_value, b_unit):
+    def get_spectrum(rsp_results, x_data, x_unit, b_value, b_unit,
+                     polarization='linear'):
         """
         Gets two-photon absorption spectrum.
 
@@ -1397,6 +1294,11 @@ class TpaTransitionDriver(NonlinearSolver):
             'TpaTransitionDriver.get_spectrum: broadening parameter should be au or ev'
         )
 
+        assert_msg_critical(
+            polarization.lower() in ['linear', 'circular'],
+            'TpaTransitionDriver.get_spectrum: polarization should be linear or circular'
+        )
+
         au2ev = hartree_in_ev()
         auxnm = 1.0 / hartree_in_inverse_nm()
 
@@ -1412,7 +1314,7 @@ class TpaTransitionDriver(NonlinearSolver):
         tpa_ene_au = []
         tpa_str = []
 
-        for state_ind, s in rsp_results['tpa_strengths']['linear'].items():
+        for state_ind, s in rsp_results['tpa_strengths'][polarization.lower()].items():
             tpa_ene_au.append(rsp_results['photon_energies'][state_ind])
             tpa_str.append(s)
 

--- a/tests/test_tpa.py
+++ b/tests/test_tpa.py
@@ -18,6 +18,36 @@ from veloxchem.scfrestdriver import ScfRestrictedDriver
 from veloxchem.rsptpa import TPA
 
 
+def assert_nested_equal(actual, expected):
+
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        actual_array = np.asarray(actual)
+        expected_array = np.asarray(expected)
+        if actual_array.dtype.kind in 'OUS' or expected_array.dtype.kind in 'OUS':
+            assert np.array_equal(actual_array, expected_array)
+        else:
+            np.testing.assert_allclose(actual_array, expected_array)
+        return
+
+    if isinstance(expected, dict):
+        assert set(actual.keys()) == set(expected.keys())
+        for key in expected:
+            assert_nested_equal(actual[key], expected[key])
+        return
+
+    if isinstance(expected, (list, tuple)):
+        assert len(actual) == len(expected)
+        for actual_item, expected_item in zip(actual, expected):
+            assert_nested_equal(actual_item, expected_item)
+        return
+
+    if isinstance(expected, (float, complex, np.floating, np.complexfloating)):
+        assert actual == pytest.approx(expected)
+        return
+
+    assert actual == expected
+
+
 @pytest.mark.solvers
 class TestTPA:
 
@@ -237,7 +267,7 @@ class TestTPA:
         outfile = tmp_path / 'tpa_reduced_summary.out'
         tpa_drv = TpaReducedDriver(MPI.COMM_WORLD, OutputStream(outfile))
         tpa_drv.frequencies = rsp_results['frequencies']
-        tpa_drv.print_results(rsp_results, sections='summary')
+        tpa_drv.print_results(rsp_results, section='summary')
         tpa_drv.ostream.flush()
 
         printed = outfile.read_text()
@@ -276,6 +306,59 @@ class TestTPA:
         assert ax.get_ylabel() == 'TPA cross-section [GM]'
         assert len(ax.lines) >= 1
         plt.close(ax.figure)
+
+    def test_reduced_driver_plot_spectrum_public_nm(self):
+
+        matplotlib = pytest.importorskip('matplotlib')
+        matplotlib.use('Agg', force=True)
+        import matplotlib.pyplot as plt
+
+        rsp_results = {
+            'gamma': {
+                (0.0, -0.0, 0.0): 1.0 + 2.0j,
+                (0.05, -0.05, 0.05): 3.0 + 4.0j,
+                (0.10, -0.10, 0.10): 5.0 + 6.0j,
+                (0.15, -0.15, 0.15): 7.0 + 8.0j,
+            },
+            'frequencies': [0.0, 0.05, 0.10, 0.15],
+            'cross_sections': [0.1, 0.2, 0.3],
+        }
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        tpa_drv = TpaReducedDriver()
+        tpa_drv.ostream.mute()
+        fig, ax = plt.subplots()
+        returned_ax = tpa_drv.plot_spectrum(rsp_results, x_unit='nm', ax=ax)
+
+        assert returned_ax is ax
+        assert ax.get_xlabel() == 'Wavelength [nm]'
+        plt.close(ax.figure)
+
+    def test_reduced_driver_note_follows_gamma_title(self, tmp_path):
+
+        rsp_results = {
+            'gamma': {
+                (0.0, -0.0, 0.0): 1.0 + 2.0j,
+                (0.05, -0.05, 0.05): 3.0 + 4.0j,
+            },
+            'frequencies': [0.0, 0.05],
+            'cross_sections': [0.1],
+        }
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        outfile = tmp_path / 'tpa_reduced_note.out'
+        tpa_drv = TpaReducedDriver(MPI.COMM_WORLD, OutputStream(outfile))
+        tpa_drv.frequencies = rsp_results['frequencies']
+        tpa_drv.print_results(rsp_results)
+        tpa_drv.ostream.flush()
+
+        printed = outfile.read_text()
+        assert printed.index('Isotropic Average gamma Tensor at Given Frequencies') < \
+            printed.index('Note: The reduced expression')
 
     def test_reduced_driver_plot_spectrum_without_ax_returns_none(self):
 
@@ -344,7 +427,7 @@ class TestTPA:
         outfile = tmp_path / 'tpa_full_summary.out'
         tpa_drv = TpaFullDriver(MPI.COMM_WORLD, OutputStream(outfile))
         tpa_drv.frequencies = rsp_results['frequencies']
-        tpa_drv.print_results(rsp_results, sections='summary')
+        tpa_drv.print_results(rsp_results, section='summary')
         tpa_drv.ostream.flush()
 
         printed = outfile.read_text()
@@ -433,7 +516,7 @@ class TestTPA:
 
         recovered = read_results(str(h5file), 'tpa_reduced')
 
-        assert recovered == tpa_drv._get_hdf5_results(rsp_results)
+        assert_nested_equal(recovered, rsp_results)
 
     def test_reduced_driver_results_hdf5_roundtrip_without_suffix(self, tmp_path):
 
@@ -460,7 +543,22 @@ class TestTPA:
 
         recovered = read_results(str(h5file), 'tpa_reduced')
 
-        assert recovered == tpa_drv._get_hdf5_results(rsp_results)
+        assert_nested_equal(recovered, rsp_results)
+
+    def test_reduced_driver_write_final_hdf5_without_filename_is_noop(self):
+
+        rsp_results = {
+            'gamma': {
+                (0.0, -0.0, 0.0): 1.0 + 2.0j,
+                (0.05, -0.05, 0.05): 3.0 + 4.0j,
+            },
+            'frequencies': [0.0, 0.05],
+            'cross_sections': [0.1],
+        }
+
+        tpa_drv = TpaReducedDriver()
+        tpa_drv.ostream.mute()
+        tpa_drv._write_final_hdf5(None, rsp_results)
 
     def test_full_driver_results_hdf5_roundtrip(self, tmp_path):
 
@@ -487,7 +585,7 @@ class TestTPA:
 
         recovered = read_results(str(h5file), 'tpa_full')
 
-        assert recovered == tpa_drv._get_hdf5_results(rsp_results)
+        assert_nested_equal(recovered, rsp_results)
 
     def test_full_driver_results_hdf5_roundtrip_without_suffix(self, tmp_path):
 
@@ -514,7 +612,22 @@ class TestTPA:
 
         recovered = read_results(str(h5file), 'tpa_full')
 
-        assert recovered == tpa_drv._get_hdf5_results(rsp_results)
+        assert_nested_equal(recovered, rsp_results)
+
+    def test_full_driver_write_final_hdf5_without_filename_is_noop(self):
+
+        rsp_results = {
+            'gamma': {
+                (0.0, -0.0, 0.0): 1.0 + 2.0j,
+                (0.05, -0.05, 0.05): 3.0 + 4.0j,
+            },
+            'frequencies': [0.0, 0.05],
+            'cross_sections': [0.1],
+        }
+
+        tpa_drv = TpaFullDriver()
+        tpa_drv.ostream.mute()
+        tpa_drv._write_final_hdf5(None, rsp_results)
 
     def test_full_driver_defaults_and_restart(self, tmp_path):
 

--- a/tests/test_tpatransition.py
+++ b/tests/test_tpatransition.py
@@ -14,6 +14,36 @@ from veloxchem.scfrestdriver import ScfRestrictedDriver
 from veloxchem.tpatransitiondriver import TpaTransitionDriver
 
 
+def assert_nested_equal(actual, expected):
+
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        actual_array = np.asarray(actual)
+        expected_array = np.asarray(expected)
+        if actual_array.dtype.kind in 'OUS' or expected_array.dtype.kind in 'OUS':
+            assert np.array_equal(actual_array, expected_array)
+        else:
+            np.testing.assert_allclose(actual_array, expected_array)
+        return
+
+    if isinstance(expected, dict):
+        assert set(actual.keys()) == set(expected.keys())
+        for key in expected:
+            assert_nested_equal(actual[key], expected[key])
+        return
+
+    if isinstance(expected, (list, tuple)):
+        assert len(actual) == len(expected)
+        for actual_item, expected_item in zip(actual, expected):
+            assert_nested_equal(actual_item, expected_item)
+        return
+
+    if isinstance(expected, (float, complex, np.floating, np.complexfloating)):
+        assert actual == pytest.approx(expected)
+        return
+
+    assert actual == expected
+
+
 @pytest.mark.solvers
 class TestTpaTransition:
 
@@ -192,7 +222,7 @@ class TestTpaTransition:
 
         outfile = tmp_path / 'tpatransition_summary.out'
         tpa_drv = TpaTransitionDriver(MPI.COMM_WORLD, OutputStream(outfile))
-        tpa_drv.print_results(tpa_results, sections='summary', max_states=1)
+        tpa_drv.print_results(tpa_results, section='summary', max_states=1)
         tpa_drv.ostream.flush()
 
         printed = outfile.read_text()
@@ -227,6 +257,32 @@ class TestTpaTransition:
         assert ax.get_ylabel() == 'TPA cross-section [GM]'
         assert len(ax.lines) == 1
         assert len(ax.figure.axes) == 2
+        plt.close(ax.figure)
+
+    def test_plot_spectrum_public_circular(self):
+
+        matplotlib = pytest.importorskip('matplotlib')
+        matplotlib.use('Agg', force=True)
+        import matplotlib.pyplot as plt
+
+        tpa_results = self.compute_tpatransition('hf')
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        tpa_drv = TpaTransitionDriver()
+        tpa_drv.ostream.mute()
+        fig, ax = plt.subplots()
+        returned_ax = tpa_drv.plot_spectrum(tpa_results,
+                                            x_unit='ev',
+                                            broadening_value=0.123984,
+                                            broadening_unit='ev',
+                                            polarization='circular',
+                                            ax=ax)
+
+        assert returned_ax is ax
+        assert len(ax.figure.axes) == 2
+        assert ax.figure.axes[1].get_ylabel() == 'TPA strengths (circular) [a.u.]'
         plt.close(ax.figure)
 
     def test_plot_spectrum_public_without_ax_returns_none(self):
@@ -288,7 +344,7 @@ class TestTpaTransition:
 
         recovered = read_results(str(h5file), 'tpa_transition')
 
-        assert recovered == tpa_drv._get_hdf5_results(tpa_results)
+        assert_nested_equal(recovered, tpa_results)
 
     def test_tpatransition_results_hdf5_roundtrip_without_suffix(self, tmp_path):
 
@@ -326,7 +382,46 @@ class TestTpaTransition:
 
         recovered = read_results(str(h5file), 'tpa_transition')
 
-        assert recovered == tpa_drv._get_hdf5_results(tpa_results)
+        assert_nested_equal(recovered, tpa_results)
+
+    def test_tpatransition_write_final_hdf5_without_filename_is_noop(self):
+
+        tpa_results = {
+            'photon_energies': [0.1656922537],
+            'transition_moments': {
+                0: np.eye(3),
+            },
+            'tpa_strengths': {
+                'linear': {0: 4.1302840736},
+                'circular': {0: 1.5},
+            },
+            'oscillator_strengths': np.array([0.01]),
+            'elec_trans_dipoles': np.array([[0.11, -0.22, 0.33]]),
+            'excitation_details': [['1a -> 2a (0.90)']],
+        }
+
+        tpa_drv = TpaTransitionDriver()
+        tpa_drv.ostream.mute()
+        tpa_drv._write_final_hdf5(None, tpa_results)
+
+    def test_transition_timing_precedes_summary_header(self, tmp_path):
+
+        if MPI.COMM_WORLD.Get_rank() != mpi_master():
+            return
+
+        scf_results, molecule, ao_basis = self.run_scf('hf')
+
+        outfile = tmp_path / 'tpatransition_compute.out'
+        tpa_drv = TpaTransitionDriver(MPI.COMM_WORLD, OutputStream(outfile))
+        tpa_drv.xcfun = 'hf'
+        tpa_drv.nstates = 2
+        tpa_drv.conv_thresh = 1.0e-7
+        tpa_drv.compute(molecule, ao_basis, scf_results)
+        tpa_drv.ostream.flush()
+
+        printed = outfile.read_text()
+        assert printed.index('Time spent in quadratic response calculation') < \
+            printed.index('Summary of Two-photon Absorption')
 
     def test_update_settings_and_restart(self, tmp_path):
 


### PR DESCRIPTION
## TPA updates

This PR cleans up the TPA user-facing API, simplifies the final HDF5 writing path, and addresses the latest review comments on output handling and plotting behavior.

### Main changes

- Simplified the public TPA printing API by using a single `print_results(...)` method with a single-word `section` argument.
- Removed the extra print normalization/wrapper layers for both gamma-based TPA and TPA-transition output.
- Simplified final HDF5 writing so the native TPA result dictionaries are written directly to the final HDF5 file instead of going through extra `_get_hdf5_results(...)` payload reshaping.
- Made final HDF5 writing optional: if no final HDF5 filename is defined, the write helper now returns quietly instead of raising.

### Gamma-based TPA drivers

- Kept the shared gamma-based user API in `TpaDriverBase` so `TpaFullDriver` and `TpaReducedDriver` stay aligned.
- Preserved only small driver-specific differences in the subclasses, such as titles, note text, and HDF5 group names.
- Adjusted reduced-driver output so the approximation note appears after the gamma title instead of before it.
- Kept references separate from `_print_note(...)`.

### TPA transition driver

- Simplified `print_results(...)` to the same direct section-based style.
- Fixed the output ordering so `Time spent in quadratic response calculation` appears before the printed TPA summary block.
- Fixed the plotting path so circular polarization is handled consistently throughout the broadened spectrum computation and stick overlay.

### Plotting

- Kept the notebook-safe plot behavior, i.e. plot methods still return `None` unless an axis is passed in.
- Cleaned up `CubicSpline` usage in `spectrumplot.py`:
  - the `try/except` only wraps the import
  - the x/y arrays are sorted before spline construction
  - the dense interpolation grid is built from the sorted data range

### Tests

- Updated focused TPA tests to match the simplified `section` API.
- Updated HDF5 roundtrip checks to validate direct result-dictionary serialization for:
  - `TpaTransitionDriver`
  - `TpaReducedDriver`
  - `TpaFullDriver`
- Added focused regression coverage for:
  - circular transition TPA plotting
  - reduced-note ordering
  - transition timing/header ordering
  - no-op final HDF5 writing when no filename is defined
  - wavelength-axis plotting/interpolation behavior

### Validation

```bash
python -m pip install --no-build-isolation .
python -m pytest -q tests/test_tpa.py tests/test_tpatransition.py
```

Result: `38 passed`
