### PR TITLE
RIXS plotting functionality

### DIFF
--- a/src/pymodule/main.py
+++ b/src/pymodule/main.py
@@ -725,8 +725,10 @@ def _main_body():
                              method_type=scf_drv.scf_type)
         rsp_prop.compute(task.molecule, task.ao_basis, scf_results)
 
-        if not rsp_prop.is_converged:
-            return 1
+        # is_converged does not apply to RIXS
+        if not isinstance(rsp_prop, RIXS):
+            if not rsp_prop.is_converged:
+                return 1
 
         # Calculate the excited-state gradient if requested
 

--- a/src/pymodule/resultsio.py
+++ b/src/pymodule/resultsio.py
@@ -378,6 +378,22 @@ def write_opt_results_to_hdf5(fname, opt_results):
                           value_label='optimization result')
 
 
+def write_rixs_results_to_hdf5(fname, rixs_results):
+    """
+    Writes optimization results to HDF5 file.
+
+    :param fname:
+        Name of the HDF5 file.
+    :param rixs_results:
+        The dictionary containing RIXS results.
+    """
+
+    write_results_to_hdf5(fname,
+                          'rixs',
+                          rixs_results,
+                          value_label='rixs result')
+
+
 def write_rsp_solution(fname, key, vec, group_label='rsp'):
     """
     Writes a response solution vector to HDF5 file.

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -548,7 +548,7 @@ class RixsDriver(LinearSolver):
         results_dict = {
             'cross_sections': self.cross_sections,
             'elastic_cross_sections': self.elastic_cross_sections,
-            'elastic_emission': self.photon_energy,
+            'photon_energies': self.photon_energy,
             'scattering_amplitudes': self.scattering_amplitudes,
             'emission_energies': self.emission_enes,
             'energy_losses': self.ene_losses,
@@ -1128,19 +1128,16 @@ class RixsDriver(LinearSolver):
         self.ostream.flush()
 
     def plot(self,
-            results,
-            broadening_type="lorentzian",
-            broadening_value_ev=0.24,
-            x_unit='ev',
-            x_step=1e-3,
-            energy_loss=True,
-            photon_index=None,
-            photon_energy_ev=None,
-            ax=None):
+             results,
+             broadening_type="lorentzian",
+             broadening_value_ev=0.24,
+             x_unit='ev',
+             x_step=1e-3,
+             energy_loss=True,
+             photon_energy_ev=None,
+             ax=None):
         """
         Plot the RIXS spectrum.
-
-        Specify either photon_index or photon_energy, not both.
 
         :param results:
             The results dictionary from compute method.
@@ -1155,55 +1152,30 @@ class RixsDriver(LinearSolver):
         :param energy_loss:
             If True, plot versus energy loss.
             If False, plot versus emission energy.
-        :param photon_index:
-            Integer index of the input energies.
         :param photon_energy_ev:
-            Photon energy in eV. The closest
+            Incoming photon energy in eV. The closest
             available calculated photon energy is used.
         :param ax:
             The matplotlib axis to plot on.
 
-        :return:
-            The matplotlib axis object.
         """
 
-        assert_msg_critical(
-            not (photon_index is not None and photon_energy_ev is not None),
-            'plot_spectrum: specify only one of photon_index or photon_energy_ev.'
-        )
-
-        nr_incoming_photons = len(results['elastic_emission'])
-
-        # if given as energy, find the closest calculated photon energy index
         if photon_energy_ev is not None:
-            incoming_photon_energies_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
+            # Find the closest calculated photon energy index
+            incoming_photon_energies_ev = np.asarray(results['photon_energies']) * hartree_in_ev()
             photon_index = int(np.argmin(np.abs(incoming_photon_energies_ev - float(photon_energy_ev))))
             closest_energy_ev = incoming_photon_energies_ev[photon_index]
 
             if abs(closest_energy_ev - photon_energy_ev) > 0.1:
                 self.ostream.print_warning(
-                    f'plot_spectrum: requested photon energy {photon_energy_ev} eV is far '
-                    f'from the closest calculated photon energy {closest_energy_ev:.2f} eV.'
-                )
-            else:
-                self.ostream.print_info(
-                    f'plot_spectrum: photon_energy_ev={photon_energy_ev} eV,'
-                    f' closest calculated photon energy is {closest_energy_ev:.2f} eV (index: {photon_index}).'
+                    f'{type(self).__name__}: requested photon energy {photon_energy_ev} eV is more '
+                    f'than 0.1 eV far from the closest calculated photon energy {closest_energy_ev:.2f} eV.'
                 )
             self.ostream.flush()
-
-        elif photon_index is None:
+        else:
             photon_index = 0
 
-        else:
-            photon_index = int(photon_index)
-
-        assert_msg_critical(
-            0 <= photon_index < nr_incoming_photons,
-            'plot_spectrum: photon_index out of range.'
-        )
-
-        return plot_rixs_spectrum(
+        plot_rixs_spectrum(
             results,
             broadening_type=broadening_type,
             broadening_value=broadening_value_ev,
@@ -1213,18 +1185,18 @@ class RixsDriver(LinearSolver):
             energy_loss=energy_loss,
             ax=ax
         )
-        
+
     def plot_map(self,
-                results,
-                broadening_type="lorentzian",
-                broadening_value_ev=0.24,
-                x_step=1e-3,
-                x_unit='ev',
-                energy_loss=True,
-                min_photon_points=10,
-                colormap='viridis',
-                normalize='global_max',
-                ax=None):
+                 results,
+                 broadening_type="lorentzian",
+                 broadening_value_ev=0.24,
+                 x_step=1e-3,
+                 x_unit='ev',
+                 energy_loss=True,
+                 min_photon_points=10,
+                 colormap='viridis',
+                 normalize='global_max',
+                 ax=None):
         """
         Plot the 2D RIXS map together with the corresponding XAS spectrum.
 
@@ -1253,17 +1225,16 @@ class RixsDriver(LinearSolver):
             Otherwise pass a tuple (ax_map, ax_xas).
         """
 
-        # the elastic emission energies correspond to the incoming photon energies,
-        # i.e., the x-axis of the XAS spectrum
-        nr_incoming_photons = len(np.asarray(results['elastic_emission']))
+        # incoming photon energies
+        nr_incoming_photons = len(np.asarray(results['photon_energies']))
 
         assert_msg_critical(
             nr_incoming_photons >= min_photon_points,
-            f'plot_map: too few incoming photon energies for a meaningful 2D RIXS map.'
+            f'{type(self).__name__}: too few incoming photon energies for a meaningful 2D RIXS map.'
             f' (min: {min_photon_points}, got: {nr_incoming_photons})'
         )
 
-        return plot_rixs_map(
+        plot_rixs_map(
             results,
             broadening_type=broadening_type,
             broadening_value=broadening_value_ev,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1222,7 +1222,8 @@ class RixsDriver(LinearSolver):
                 x_unit='ev',
                 energy_loss=True,
                 min_photon_points=10,
-                colormap='cividis',
+                colormap='viridis',
+                normalize='global_max',
                 ax=None):
         """
         Plot the 2D RIXS map together with the corresponding XAS spectrum.
@@ -1244,17 +1245,22 @@ class RixsDriver(LinearSolver):
             Minimum number of incoming photon energies required for a meaningful map.
         :param colormap:
             The colormap to use for the RIXS map.
+        :param normalize:
+            Normalization method for the RIXS map.
+            'global_max': normalize by the global maximum of the RIXS intensities -> range of intensity [0-1] (default).
         :param ax:
             If None, new axes are created.
             Otherwise pass a tuple (ax_map, ax_xas).
         """
 
-        n_photons = len(np.asarray(results['elastic_emission']))
+        # the elastic emission energies correspond to the incoming photon energies,
+        # i.e., the x-axis of the XAS spectrum
+        nr_incoming_photons = len(np.asarray(results['elastic_emission']))
 
         assert_msg_critical(
-            n_photons >= min_photon_points,
-            'plot_map: too few incoming photon energies for a meaningful 2D RIXS map. '
-            'Use plot_spectrum(..., photon_index=[...]) for stacked slices instead.'
+            nr_incoming_photons >= min_photon_points,
+            f'plot_map: too few incoming photon energies for a meaningful 2D RIXS map.'
+            f' (min: {min_photon_points}, got: {nr_incoming_photons})'
         )
 
         return plot_rixs_map(
@@ -1265,5 +1271,6 @@ class RixsDriver(LinearSolver):
             x_unit=x_unit,
             energy_loss=energy_loss,
             cmap=colormap,
+            normalize=normalize,
             ax=ax
         )

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1127,35 +1127,6 @@ class RixsDriver(LinearSolver):
         self.ostream.print_blank()
         self.ostream.flush()
 
-    @staticmethod
-    def _select_photon_index(results, photon_index=None, photon_energy=None):
-        """
-        Function for returning the index of the selected photon. Based on either
-        the photon index or the photon energy. If both are None, return 0.
-        """
-        assert_msg_critical(
-            not (photon_index is not None and photon_energy is not None),
-            'plot_spectrum: specify only one of photon_index or photon_energy.'
-        )
-
-        if photon_index is None and photon_energy is None:
-            return 0
-
-        if photon_energy is not None:
-            incoming_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
-            photon_energy = float(photon_energy)
-
-            return int(np.argmin(np.abs(incoming_ev - photon_energy)))
-
-        photon_index = int(photon_index)
-        n_photons = len(results['elastic_emission'])
-        assert_msg_critical(
-            0 <= photon_index < n_photons,
-            'plot_spectrum: photon_index out of range.'
-        )
-
-        return photon_index
-
     def plot(self,
             results,
             broadening_type="lorentzian",
@@ -1196,18 +1167,46 @@ class RixsDriver(LinearSolver):
             The matplotlib axis object.
         """
 
+        assert_msg_critical(
+            not (photon_index is not None and photon_energy_ev is not None),
+            'plot_spectrum: specify only one of photon_index or photon_energy_ev.'
+        )
+
+        nr_incoming_photons = len(results['elastic_emission'])
+
         # if given as energy, find the closest calculated photon energy index
-        photon_selection = self._select_photon_index(
-            results,
-            photon_index=photon_index,
-            photon_energy=photon_energy_ev
+        if photon_energy_ev is not None:
+            incoming_photon_energies_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
+            photon_index = int(np.argmin(np.abs(incoming_photon_energies_ev - float(photon_energy_ev))))
+            closest_energy_ev = incoming_photon_energies_ev[photon_index]
+
+            if abs(closest_energy_ev - photon_energy_ev) > 0.1:
+                self.ostream.print_warning(
+                    f'plot_spectrum: requested photon energy {photon_energy_ev} eV is far '
+                    f'from the closest calculated photon energy {closest_energy_ev:.2f} eV.'
+                )
+            else:
+                self.ostream.print_info(
+                    f'plot_spectrum: photon_energy_ev={photon_energy_ev} eV,'
+                    f' closest calculated photon energy is {closest_energy_ev:.2f} eV (index: {photon_index}).'
+                )
+
+        elif photon_index is None:
+            photon_index = 0
+
+        else:
+            photon_index = int(photon_index)
+
+        assert_msg_critical(
+            0 <= photon_index < nr_incoming_photons,
+            'plot_spectrum: photon_index out of range.'
         )
 
         return plot_rixs_spectrum(
             results,
             broadening_type=broadening_type,
             broadening_value=broadening_value_ev,
-            photon_index=photon_selection,
+            photon_index=photon_index,
             x_unit=x_unit,
             x_step=x_step,
             energy_loss=energy_loss,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1190,6 +1190,7 @@ class RixsDriver(LinearSolver):
                     f'plot_spectrum: photon_energy_ev={photon_energy_ev} eV,'
                     f' closest calculated photon energy is {closest_energy_ev:.2f} eV (index: {photon_index}).'
                 )
+            self.ostream.flush()
 
         elif photon_index is None:
             photon_index = 0

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -44,6 +44,7 @@ from .linearsolver import LinearSolver
 from .lreigensolver import LinearResponseEigenSolver
 from .tdaeigensolver import TdaEigenSolver
 from .errorhandler import assert_msg_critical
+from .resultsio import write_rixs_results_to_hdf5
 
 
 class RixsDriver(LinearSolver):
@@ -116,7 +117,7 @@ class RixsDriver(LinearSolver):
                 ('float', 'angle between incident polarization vector and ' +
                     'outgoing propagation vector'),
             'gamma': ('float', 'broadening term (FWHM)'),
-            'photon_energy': ('list', 'list of incoming photon energies'),
+            'photon_energy': ('seq_range', 'list of incoming photon energies'),
             'final_state_cutoff':
                 ('float', 'energy window of final states to include'),
             'nstates': ('int', 'number of excited states'),
@@ -142,35 +143,6 @@ class RixsDriver(LinearSolver):
 
         if method_dict is None:
             method_dict = {}
-
-        key = 'photon_energy'
-        if key in rsp_dict:
-            val = rsp_dict[key]
-
-            if isinstance(val, (list, tuple, np.ndarray)):
-                if len(val) == 0:
-                    raise ValueError(
-                        'RixsDriver.update_settings: photon_energy must '
-                        'contain at least one numeric value.')
-                try:
-                    rsp_dict[key] = [float(str(x).strip()) for x in val]
-                except ValueError as exc:
-                    raise ValueError(
-                        'RixsDriver.update_settings: Invalid photon_energy '
-                        'value. Expected numeric values.') from exc
-
-            elif isinstance(val, str):
-                parts = val.replace(',', ' ').split()
-                if len(parts) == 0:
-                    raise ValueError(
-                        'RixsDriver.update_settings: photon_energy must '
-                        'contain at least one numeric value.')
-                try:
-                    rsp_dict[key] = [float(x) for x in parts]
-                except ValueError as exc:
-                    raise ValueError(
-                        'RixsDriver.update_settings: Invalid photon_energy '
-                        'value. Expected numeric values.') from exc
 
         super().update_settings(rsp_dict, method_dict)
 
@@ -558,20 +530,14 @@ class RixsDriver(LinearSolver):
         }
 
         if self.filename is not None and self.rank == mpi_master():
-            self.ostream.print_info('Writing to files...')
-            self.ostream.print_blank()
-            self.ostream.flush()
-            self._write_hdf5(self.filename)
+            final_h5_fname = self.filename + ".h5"
+            self._write_hdf5(final_h5_fname, results_dict)
 
         if not init_photon_set:
             self.photon_energy = None
 
-        if self.rank == mpi_master():
-            self.ostream.print_info('...done.')
-            self.ostream.print_blank()
-            self.ostream.flush()
-
         return results_dict
+
 
     def _first_core_energy(self, rsp_results):
         """
@@ -895,52 +861,28 @@ class RixsDriver(LinearSolver):
         )
         return gs_to_core, core_to_val
 
-    def _write_hdf5(self, fname):
+    def _write_hdf5(self, fname, rixs_results):
         """
         Writes the RIXS results to the specified output file in h5
         format. The h5 file saved contains the following datasets:
 
-        - photon_energies
-            The incoming photon energies (w, or omega), at which the RIXS amplitudes
-            are computed and so also the cross-sections.
-        - cross_sections
-            The RIXS cross-sections per photon energy (w, or omega), per final state (f),
-            with shape: (f,w).
-        - emission_energies
-            The outgoing, or scattered, photon energy.
-        - energy_losses
-            The energy (> 0) which the molecule is left with, i.e., incoming - outgoing.
-        - elastic_cross_sections
-            The cross-section for elastic scattering, i.e., energy loss = 0.
-        - scattering_amplitudes
-            The scattering ampltitude tensor, with shape: (f,w,x,y).
-
         :param fname:
-            Name of the h5 file.
+            Name of the HDF5 file.
+        :param rixs_results:
+            The dictionary of rixs results.
         """
 
-        if not fname:
-            raise ValueError('No filename given to _write_hdf5()')
+        if (fname and isinstance(fname, str) and Path(fname).is_file()):
 
-        fpath = Path(fname)
-        if fpath.suffix != '.h5':
-            fpath = fpath.with_suffix('.h5')
+            write_rixs_results_to_hdf5(fname, rixs_results)
 
-        # Save all the internal data to the h5 datafile named 'fname'
-        with h5py.File(fpath, 'a') as hf:
-            datasets = {
-                'rixs/photon_energies': self.photon_energy,
-                'rixs/cross_sections': self.cross_sections,
-                'rixs/emission_energies': self.emission_enes,
-                'rixs/energy_losses': self.ene_losses,
-                'rixs/elastic_cross_sections': self.elastic_cross_sections,
-                'rixs/scattering_amplitudes': self.scattering_amplitudes,
-            }
+            valstr = 'RIXS results written to file: '
+            valstr += fname
+            self.ostream.print_info(valstr)
+            self.ostream.print_blank()
+            self.ostream.flush()
 
-            for name, data in datasets.items():
-                if name in hf:
-                    del hf[name]
-                hf.create_dataset(name, data=data)
+
 
     def _print_header(self, molecule, basis):
         """

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -310,6 +310,7 @@ class RixsDriver(LinearSolver):
 
         if self.twoshot:
             self._approach_string = 'Running RIXS calculation in the two-shot approach'
+            self._method_ref_str = 'J. Chem. Theory Comput. 2021, 17, 3031-3038, DOI: 10.1021/acs.jctc.1c00144'
 
             if self.rank == mpi_master():
                 num_core_orbitals = cvs_rsp_results['num_core']
@@ -334,6 +335,7 @@ class RixsDriver(LinearSolver):
 
         else:
             self._approach_string = 'Running RIXS calculation in the restricted-subspace approach'
+            self._method_ref_str = 'Phys. Chem. Chem. Phys., 2021, 23, 1835-1848, DOI: 10.1039/d0cp04726k'
 
             if self.rank == mpi_master():
                 num_valence_orbitals = rsp_results['num_valence']
@@ -1074,8 +1076,14 @@ class RixsDriver(LinearSolver):
             )
             self.ostream.print_blank()
 
+        self._implementation_ref_str = 'J. Phys. Chem. A 2025, 129, 8783-8797, DOI: 10.1021/acs.jpca.5c04528'
+        self.ostream.print_info('Implementation details & benchmark: ')
+        self.ostream.print_reference('Reference: ' + self._implementation_ref_str)
+        self.ostream.print_blank()
+
         if getattr(self, "_approach_string", None):
             self.ostream.print_info(self._approach_string)
+            self.ostream.print_reference('Reference: ' + self._method_ref_str)
             self.ostream.print_blank()
 
         self.ostream.flush()

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1110,3 +1110,46 @@ class RixsDriver(LinearSolver):
             self.ostream.print_header(valstr.ljust(92))
         self.ostream.print_blank()
         self.ostream.flush()
+
+    def plot_spectrum(self,
+                      results,
+                      broadening_type="lorentzian",
+                      broadening_value=0.15,
+                      x_unit='ev',
+                      energy_loss=True,
+                      photon_index=0,
+                      ax=None):
+        """
+        Plot the RIXS spectrum for a single element from the computed results.
+
+        :param results:
+            The results dictionary from compute method.
+        :param element:
+            Element symbol to plot (e.g., 'C', 'O', 'N', 'F', 'S').
+            If None and results contains only one element, that element is plotted.
+            If None and results contains multiple elements, an error is raised.
+        :param broadening_type:
+            The type of broadening to use. Either 'lorentzian' or 'gaussian'.
+        :param broadening_value:
+            The broadening value (FWHM) in eV.
+        :param color:
+            Color scheme for plotting. Either 'vlx' for VeloxChem default color (darkcyan)
+            or 'cpk' for CPK coloring (element-specific colors). Default is 'vlx'.
+        :param show_atom_labels:
+            If True, display atom indices as labels above peaks. Default is True.
+        :param color_by_atom:
+            If True, color each peak according to its atom index instead of using 
+            element color. Default is False.
+        :param ax:
+            The matplotlib axis to plot on. If None, a new figure is created.
+
+        :return:
+            The matplotlib axis object.
+        """
+        plot_rixs_spectrum(results,
+                          broadening_type=broadening_type,
+                          broadening_value=broadening_value,
+                          photon_index=photon_index,
+                          x_unit=x_unit,
+                          energy_loss=energy_loss,
+                          ax=ax)

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -36,9 +36,9 @@ import numpy as np
 import h5py
 import sys
 
-from .veloxchemlib import hartree_in_ev, mpi_master
+from .veloxchemlib import hartree_in_ev, mpi_master, fine_structure_constant
 from .oneeints import compute_electric_dipole_integrals
-from .spectrumplot import plot_rixs_spectrum, plot_rixs_map, plot_rixs_slices
+from .spectrumplot import plot_rixs_spectrum, plot_rixs_map
 from .outputstream import OutputStream
 from .linearsolver import LinearSolver
 from .lreigensolver import LinearResponseEigenSolver
@@ -399,8 +399,8 @@ class RixsDriver(LinearSolver):
         core_eigvals = self.comm.bcast(core_eigvals, root=mpi_master())
         valence_eigvals = self.comm.bcast(valence_eigvals, root=mpi_master())
 
-        core_eigvecs = self._get_eigvecs(core_rsp_results, core_states, "core")
-        valence_eigvecs = self._get_eigvecs(rsp_results, val_states, "valence")
+        core_eigvecs = self._get_eigvecs(core_rsp_results, core_states)
+        valence_eigvecs = self._get_eigvecs(rsp_results, val_states)
 
         core_mats = self._preprocess_core_eigvecs(core_eigvecs, occupied_core,
                                                   num_valence_orbitals, num_vir_orbitals)
@@ -699,7 +699,7 @@ class RixsDriver(LinearSolver):
 
     def cross_section(self, F, omegaprime_omega=1):
         """
-        Computes the RIXS cross-section.
+        Computes the RIXS cross section.
 
         Journal of Chemical Theory and Computation 2021 17 (5), 3031-3038
         DOI: 10.1021/acs.jctc.1c00144
@@ -713,7 +713,7 @@ class RixsDriver(LinearSolver):
             The ratio between outgoing- and incoming frequencies, w'/w.
 
         :return:
-            The scattering cross-section.
+            The scattering cross section.
         """
 
         # F_xy (F^(xy))^*
@@ -723,13 +723,13 @@ class RixsDriver(LinearSolver):
         # F_xx (F^(yy))^*
         tr_F2 = np.abs(np.trace(F))**2
 
-        sigma_f = omegaprime_omega * (1.0/15.0) * (
+        sigma_f = (fine_structure_constant()**4) * omegaprime_omega * (1.0/15.0) * (
             (2.0 - 0.5*np.sin(self.theta)**2) * F2 +
             (0.75*np.sin(self.theta)**2 - 0.5) * (FF_T_conj + tr_F2))
 
         return sigma_f
 
-    def _get_eigvecs(self, rsp_results, states, label):
+    def _get_eigvecs(self, rsp_results, states):
         """
         Gets eigenvectors.
 
@@ -1128,48 +1128,43 @@ class RixsDriver(LinearSolver):
         self.ostream.flush()
 
     @staticmethod
-    def _resolve_photon_selection(results, photon_index=None, photon_energy=None):
+    def _select_photon_index(results, photon_index=None, photon_energy=None):
+        """
+        Function for returning the index of the selected photon. Based on either
+        the photon index or the photon energy. If both are None, return 0.
+        """
         assert_msg_critical(
             not (photon_index is not None and photon_energy is not None),
             'plot_spectrum: specify only one of photon_index or photon_energy.'
         )
 
-        incoming_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
-
         if photon_index is None and photon_energy is None:
             return 0
 
         if photon_energy is not None:
-            energies = np.atleast_1d(photon_energy).astype(float)
-            indices = np.argmin(np.abs(incoming_ev[:, None] - energies[None, :]),
-                                axis=0)
+            incoming_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
+            photon_energy = float(photon_energy)
 
-            if np.ndim(photon_energy) == 0:
-                return int(indices[0])
+            return int(np.argmin(np.abs(incoming_ev - photon_energy)))
 
-            return indices.astype(int)
-
-        indices = np.atleast_1d(photon_index).astype(int)
-
+        photon_index = int(photon_index)
+        n_photons = len(results['elastic_emission'])
         assert_msg_critical(
-            np.all(indices >= 0) and np.all(indices < incoming_ev.size),
+            0 <= photon_index < n_photons,
             'plot_spectrum: photon_index out of range.'
         )
 
-        if np.ndim(photon_index) == 0:
-            return int(indices[0])
-
-        return indices
+        return photon_index
 
     def plot(self,
             results,
             broadening_type="lorentzian",
             broadening_value_ev=0.24,
             x_unit='ev',
+            x_step=1e-3,
             energy_loss=True,
             photon_index=None,
             photon_energy_ev=None,
-            normalize=True,
             ax=None):
         """
         Plot the RIXS spectrum.
@@ -1184,16 +1179,16 @@ class RixsDriver(LinearSolver):
             The broadening value, FWHM in eV.
         :param x_unit:
             Unit for the x-axis.
+        :param x_step:
+            Grid spacing in eV for the broadened RIXS spectrum.
         :param energy_loss:
             If True, plot versus energy loss.
             If False, plot versus emission energy.
         :param photon_index:
-            Integer index for a single slice, or list of indices for stacked slices.
+            Integer index of the input energies.
         :param photon_energy_ev:
-            Photon energy in eV, or list of photon energies in eV. The closest
+            Photon energy in eV. The closest
             available calculated photon energy is used.
-        :param normalize:
-            If True, normalize the cross-sections (based on max intenstiy).
         :param ax:
             The matplotlib axis to plot on.
 
@@ -1201,40 +1196,29 @@ class RixsDriver(LinearSolver):
             The matplotlib axis object.
         """
 
-        # if given as energies, find the closest calculated photon energy indices
-        photon_selection = self._resolve_photon_selection(
+        # if given as energy, find the closest calculated photon energy index
+        photon_selection = self._select_photon_index(
             results,
             photon_index=photon_index,
             photon_energy=photon_energy_ev
         )
 
-        if isinstance(photon_selection, np.ndarray):
-            return plot_rixs_slices(
-                results,
-                photon_indices=photon_selection,
-                broadening_type=broadening_type,
-                broadening_value=broadening_value_ev,
-                x_unit=x_unit,
-                energy_loss=energy_loss,
-                normalize=normalize,
-                ax=ax
-            )
-        else:
-            return plot_rixs_spectrum(
-                results,
-                broadening_type=broadening_type,
-                broadening_value=broadening_value_ev,
-                photon_index=photon_selection,
-                x_unit=x_unit,
-                energy_loss=energy_loss,
-                ax=ax
-            )
+        return plot_rixs_spectrum(
+            results,
+            broadening_type=broadening_type,
+            broadening_value=broadening_value_ev,
+            photon_index=photon_selection,
+            x_unit=x_unit,
+            x_step=x_step,
+            energy_loss=energy_loss,
+            ax=ax
+        )
         
     def plot_map(self,
                 results,
                 broadening_type="lorentzian",
                 broadening_value_ev=0.24,
-                x_step=0.01,
+                x_step=1e-3,
                 x_unit='ev',
                 energy_loss=True,
                 min_photon_points=10,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -38,6 +38,7 @@ import sys
 
 from .veloxchemlib import hartree_in_ev, mpi_master
 from .oneeints import compute_electric_dipole_integrals
+from .spectrumplot import plot_rixs_spectrum
 from .outputstream import OutputStream
 from .linearsolver import LinearSolver
 from .lreigensolver import LinearResponseEigenSolver
@@ -1124,10 +1125,6 @@ class RixsDriver(LinearSolver):
 
         :param results:
             The results dictionary from compute method.
-        :param element:
-            Element symbol to plot (e.g., 'C', 'O', 'N', 'F', 'S').
-            If None and results contains only one element, that element is plotted.
-            If None and results contains multiple elements, an error is raised.
         :param broadening_type:
             The type of broadening to use. Either 'lorentzian' or 'gaussian'.
         :param broadening_value:
@@ -1135,11 +1132,6 @@ class RixsDriver(LinearSolver):
         :param color:
             Color scheme for plotting. Either 'vlx' for VeloxChem default color (darkcyan)
             or 'cpk' for CPK coloring (element-specific colors). Default is 'vlx'.
-        :param show_atom_labels:
-            If True, display atom indices as labels above peaks. Default is True.
-        :param color_by_atom:
-            If True, color each peak according to its atom index instead of using 
-            element color. Default is False.
         :param ax:
             The matplotlib axis to plot on. If None, a new figure is created.
 

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -38,7 +38,7 @@ import sys
 
 from .veloxchemlib import hartree_in_ev, mpi_master
 from .oneeints import compute_electric_dipole_integrals
-from .spectrumplot import plot_rixs_spectrum
+from .spectrumplot import plot_rixs_spectrum, plot_rixs_map, plot_rixs_slices
 from .outputstream import OutputStream
 from .linearsolver import LinearSolver
 from .lreigensolver import LinearResponseEigenSolver
@@ -200,7 +200,7 @@ class RixsDriver(LinearSolver):
                 f'({ce_states}, {ve_states})')
 
     def compute(self, molecule, basis, scf_results,
-                rsp_results=None, cvs_rsp_results=None):
+                rsp_results=None, core_rsp_results=None):
         """
         Computes RIXS properties.
 
@@ -212,7 +212,7 @@ class RixsDriver(LinearSolver):
             The results dictionary from converged SCF wavefunction.
         :rsp_results:
             The linear-response results dictionary.
-        :cvs_rsp_results:
+        :core_rsp_results:
             The core-valence-separated (CVS) linear-response
             results dictionary.
 
@@ -267,7 +267,7 @@ class RixsDriver(LinearSolver):
 
             rsp_results = rsp_drv.compute(molecule, basis, scf_results)
 
-        if cvs_rsp_results is None and (not self.restricted_subspace):
+        if core_rsp_results is None and (not self.restricted_subspace):
 
             cvs_rsp_keys = [
                 'num_core_orbitals',
@@ -295,7 +295,7 @@ class RixsDriver(LinearSolver):
                 fpath = fpath.with_name(fpath.stem)
                 cvs_rsp_drv.checkpoint_file = str(fpath) + '_rixs_cvs.h5'
 
-            cvs_rsp_results = cvs_rsp_drv.compute(molecule, basis, scf_results)
+            core_rsp_results = cvs_rsp_drv.compute(molecule, basis, scf_results)
 
         nocc = molecule.number_of_alpha_occupied_orbitals(basis)
 
@@ -313,9 +313,9 @@ class RixsDriver(LinearSolver):
             self._method_ref_str = 'J. Chem. Theory Comput. 2021, 17, 3031-3038, DOI: 10.1021/acs.jctc.1c00144'
 
             if self.rank == mpi_master():
-                num_core_orbitals = cvs_rsp_results['num_core']
+                num_core_orbitals = core_rsp_results['num_core']
                 num_valence_orbitals = nocc - num_core_orbitals
-                num_intermediate_states = len(cvs_rsp_results['eigenvalues'])
+                num_intermediate_states = len(core_rsp_results['eigenvalues'])
                 num_final_states = len(rsp_results['eigenvalues'])
             else:
                 num_core_orbitals = None
@@ -373,7 +373,7 @@ class RixsDriver(LinearSolver):
             val_states = self.comm.bcast(val_states, root=mpi_master())
 
             # For compatibility with the two-shot approach
-            cvs_rsp_results = rsp_results
+            core_rsp_results = rsp_results
             occupied_core = num_core_orbitals + num_valence_orbitals
 
         mo_core_indices = list(range(num_core_orbitals))
@@ -384,7 +384,7 @@ class RixsDriver(LinearSolver):
             mo_occ = scf_results['C_alpha'][:, mo_core_indices + mo_val_indices].copy()
             mo_vir = scf_results['C_alpha'][:, mo_vir_indices].copy()
 
-            core_eigvals = cvs_rsp_results['eigenvalues'][core_states].copy()
+            core_eigvals = core_rsp_results['eigenvalues'][core_states].copy()
             valence_eigvals = rsp_results['eigenvalues'][val_states].copy()
         else:
             mo_occ = None
@@ -399,7 +399,7 @@ class RixsDriver(LinearSolver):
         core_eigvals = self.comm.bcast(core_eigvals, root=mpi_master())
         valence_eigvals = self.comm.bcast(valence_eigvals, root=mpi_master())
 
-        core_eigvecs = self._get_eigvecs(cvs_rsp_results, core_states, "core")
+        core_eigvecs = self._get_eigvecs(core_rsp_results, core_states, "core")
         valence_eigvecs = self._get_eigvecs(rsp_results, val_states, "valence")
 
         core_mats = self._preprocess_core_eigvecs(core_eigvecs, occupied_core,
@@ -428,10 +428,10 @@ class RixsDriver(LinearSolver):
             init_photon_set = False
 
             if self.rank == mpi_master():
-                if cvs_rsp_results is None:
+                if core_rsp_results is None:
                     osc_arr = rsp_results['oscillator_strengths']
                 else:
-                    osc_arr = cvs_rsp_results['oscillator_strengths']
+                    osc_arr = core_rsp_results['oscillator_strengths']
             else:
                 osc_arr = None
             osc_arr = self.comm.bcast(osc_arr, root=mpi_master())
@@ -552,6 +552,9 @@ class RixsDriver(LinearSolver):
             'scattering_amplitudes': self.scattering_amplitudes,
             'emission_energies': self.emission_enes,
             'energy_losses': self.ene_losses,
+            'core_eigenvalues': core_rsp_results['eigenvalues'][core_states],
+            'core_osc_strengths': core_rsp_results['oscillator_strengths'][core_states],
+            'gamma_fwhm_ev': self.gamma * hartree_in_ev(),
         }
 
         if self.filename is not None and self.rank == mpi_master():
@@ -1095,8 +1098,12 @@ class RixsDriver(LinearSolver):
 
         :param title:
             The title to be printed to the output stream.
-        :param results:
-            The dictionary containing response results.
+        :param ene_losses:
+            The list of energy losses.
+        :param cross_sections:
+            The list of cross-sections.
+        :param elastic_cross_section:
+            The elastic cross-section.
         """
 
         spin_str = 'S'
@@ -1120,36 +1127,159 @@ class RixsDriver(LinearSolver):
         self.ostream.print_blank()
         self.ostream.flush()
 
-    def plot_spectrum(self,
-                      results,
-                      broadening_type="lorentzian",
-                      broadening_value=0.15,
-                      x_unit='ev',
-                      energy_loss=True,
-                      photon_index=0,
-                      ax=None):
+    @staticmethod
+    def _resolve_photon_selection(results, photon_index=None, photon_energy=None):
+        assert_msg_critical(
+            not (photon_index is not None and photon_energy is not None),
+            'plot_spectrum: specify only one of photon_index or photon_energy.'
+        )
+
+        incoming_ev = np.asarray(results['elastic_emission']) * hartree_in_ev()
+
+        if photon_index is None and photon_energy is None:
+            return 0
+
+        if photon_energy is not None:
+            energies = np.atleast_1d(photon_energy).astype(float)
+            indices = np.argmin(np.abs(incoming_ev[:, None] - energies[None, :]),
+                                axis=0)
+
+            if np.ndim(photon_energy) == 0:
+                return int(indices[0])
+
+            return indices.astype(int)
+
+        indices = np.atleast_1d(photon_index).astype(int)
+
+        assert_msg_critical(
+            np.all(indices >= 0) and np.all(indices < incoming_ev.size),
+            'plot_spectrum: photon_index out of range.'
+        )
+
+        if np.ndim(photon_index) == 0:
+            return int(indices[0])
+
+        return indices
+
+    def plot(self,
+            results,
+            broadening_type="lorentzian",
+            broadening_value_ev=0.24,
+            x_unit='ev',
+            energy_loss=True,
+            photon_index=None,
+            photon_energy_ev=None,
+            normalize=True,
+            ax=None):
         """
-        Plot the RIXS spectrum for a single element from the computed results.
+        Plot the RIXS spectrum.
+
+        Specify either photon_index or photon_energy, not both.
 
         :param results:
             The results dictionary from compute method.
         :param broadening_type:
             The type of broadening to use. Either 'lorentzian' or 'gaussian'.
         :param broadening_value:
-            The broadening value (FWHM) in eV.
-        :param color:
-            Color scheme for plotting. Either 'vlx' for VeloxChem default color (darkcyan)
-            or 'cpk' for CPK coloring (element-specific colors). Default is 'vlx'.
+            The broadening value, FWHM in eV.
+        :param x_unit:
+            Unit for the x-axis.
+        :param energy_loss:
+            If True, plot versus energy loss.
+            If False, plot versus emission energy.
+        :param photon_index:
+            Integer index for a single slice, or list of indices for stacked slices.
+        :param photon_energy_ev:
+            Photon energy in eV, or list of photon energies in eV. The closest
+            available calculated photon energy is used.
+        :param normalize:
+            If True, normalize the cross-sections (based on max intenstiy).
         :param ax:
-            The matplotlib axis to plot on. If None, a new figure is created.
+            The matplotlib axis to plot on.
 
         :return:
             The matplotlib axis object.
         """
-        plot_rixs_spectrum(results,
-                          broadening_type=broadening_type,
-                          broadening_value=broadening_value,
-                          photon_index=photon_index,
-                          x_unit=x_unit,
-                          energy_loss=energy_loss,
-                          ax=ax)
+
+        # if given as energies, find the closest calculated photon energy indices
+        photon_selection = self._resolve_photon_selection(
+            results,
+            photon_index=photon_index,
+            photon_energy=photon_energy_ev
+        )
+
+        if isinstance(photon_selection, np.ndarray):
+            return plot_rixs_slices(
+                results,
+                photon_indices=photon_selection,
+                broadening_type=broadening_type,
+                broadening_value=broadening_value_ev,
+                x_unit=x_unit,
+                energy_loss=energy_loss,
+                normalize=normalize,
+                ax=ax
+            )
+        else:
+            return plot_rixs_spectrum(
+                results,
+                broadening_type=broadening_type,
+                broadening_value=broadening_value_ev,
+                photon_index=photon_selection,
+                x_unit=x_unit,
+                energy_loss=energy_loss,
+                ax=ax
+            )
+        
+    def plot_map(self,
+                results,
+                broadening_type="lorentzian",
+                broadening_value_ev=0.24,
+                x_step=0.01,
+                x_unit='ev',
+                energy_loss=True,
+                min_photon_points=10,
+                colormap='cividis',
+                ax=None):
+        """
+        Plot the 2D RIXS map together with the corresponding XAS spectrum.
+
+        :param results:
+            The RIXS results dictionary from the compute method.
+        :param broadening_type:
+            The type of broadening to use. Either 'lorentzian' or 'gaussian'.
+        :param broadening_value_ev:
+            The broadening value, FWHM in eV.
+        :param x_step:
+            Grid spacing in eV for the broadened RIXS map.
+        :param x_unit:
+            Currently only 'ev' is supported.
+        :param energy_loss:
+            If True, plot versus energy loss.
+            If False, plot versus emission energy.
+        :param min_photon_points:
+            Minimum number of incoming photon energies required for a meaningful map.
+        :param colormap:
+            The colormap to use for the RIXS map.
+        :param ax:
+            If None, new axes are created.
+            Otherwise pass a tuple (ax_map, ax_xas).
+        """
+
+        n_photons = len(np.asarray(results['elastic_emission']))
+
+        assert_msg_critical(
+            n_photons >= min_photon_points,
+            'plot_map: too few incoming photon energies for a meaningful 2D RIXS map. '
+            'Use plot_spectrum(..., photon_index=[...]) for stacked slices instead.'
+        )
+
+        return plot_rixs_map(
+            results,
+            broadening_type=broadening_type,
+            broadening_value=broadening_value_ev,
+            x_step=x_step,
+            x_unit=x_unit,
+            energy_loss=energy_loss,
+            cmap=colormap,
+            ax=ax
+        )

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1093,6 +1093,7 @@ class RixsDriver(LinearSolver):
              xstep=1e-4,
              energy_loss=True,
              photon_energy_ev=None,
+             plot_elastic_line=False,
              ax=None):
         """
         Plot the RIXS spectrum.
@@ -1113,6 +1114,8 @@ class RixsDriver(LinearSolver):
         :param photon_energy_ev:
             Incoming photon energy in eV. The closest
             available calculated photon energy is used.
+        :param plot_elastic_line:
+            If True, include the elastic line in the plot.
         :param ax:
             The matplotlib axis to plot on.
 
@@ -1141,6 +1144,7 @@ class RixsDriver(LinearSolver):
             x_unit=x_unit,
             xstep=xstep,
             energy_loss=energy_loss,
+            plot_elastic_line=plot_elastic_line,
             ax=ax
         )
 
@@ -1154,6 +1158,7 @@ class RixsDriver(LinearSolver):
                  min_photon_points=10,
                  colormap='viridis',
                  normalize='global_max',
+                 plot_elastic_line=False,
                  ax=None):
         """
         Plot the 2D RIXS map together with the corresponding XAS spectrum.
@@ -1178,6 +1183,8 @@ class RixsDriver(LinearSolver):
         :param normalize:
             Normalization method for the RIXS map.
             'global_max': normalize by the global maximum of the RIXS intensities -> range of intensity [0-1] (default).
+        :param plot_elastic_line:
+            If True, include the elastic line in the RIXS map.
         :param ax:
             If None, new axes are created.
             Otherwise pass a tuple (ax_map, ax_xas).
@@ -1201,5 +1208,6 @@ class RixsDriver(LinearSolver):
             energy_loss=energy_loss,
             cmap=colormap,
             normalize=normalize,
+            plot_elastic_line=plot_elastic_line,
             ax=ax
         )

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1021,17 +1021,33 @@ class RixsDriver(LinearSolver):
             )
             self.ostream.print_blank()
 
-        self._implementation_ref_str = 'J. Phys. Chem. A 2025, 129, 8783-8797, DOI: 10.1021/acs.jpca.5c04528'
         self.ostream.print_info('Implementation details & benchmark: ')
-        self.ostream.print_reference('Reference: ' + self._implementation_ref_str)
+        self.ostream.print_reference('Reference: ' + self._reference_dictionary()['implementation'])
         self.ostream.print_blank()
 
-        if getattr(self, "_approach_string", None):
-            self.ostream.print_info(self._approach_string)
-            self.ostream.print_reference('Reference: ' + self._method_ref_str)
-            self.ostream.print_blank()
+        #if getattr(self, "_approach_string", None):
+        if self.twoshot:
+            approach_string = 'Running RIXS calculation in the two-shot approach'
+            approach_key = 'twoshot'
+        else:
+            approach_string = 'Running RIXS calculation in the restricted-subspace approach'
+            approach_key = 'rsa'
+        self.ostream.print_info(approach_string)
+        self.ostream.print_reference(self._reference_dictionary()[approach_key])
+        self.ostream.print_blank()
 
         self.ostream.flush()
+
+    def _reference_dictionary(self):
+        """
+        Returns a dictionary of references for the method used.
+        """
+
+        return {
+            'implementation': 'J. Phys. Chem. A 2025, 129, 8783-8797, DOI: 10.1021/acs.jpca.5c04528',
+            'rsa': 'J. Chem. Theory Comput. 2019, 15, 5925-5942, DOI: 10.1021/acs.jctc.9b00638',
+            'twoshot': 'J. Phys. Chem. A 2025, 129, 8783-8797, DOI: 10.1021/acs.jpca.5c04528',
+        }
 
     def _print_rixs_data(self, title, ene_losses,
                          cross_sections, elastic_cross_section):
@@ -1074,7 +1090,7 @@ class RixsDriver(LinearSolver):
              broadening_type="lorentzian",
              broadening_value_ev=0.24,
              x_unit='ev',
-             x_step=1e-4,
+             xstep=1e-4,
              energy_loss=True,
              photon_energy_ev=None,
              ax=None):
@@ -1085,11 +1101,11 @@ class RixsDriver(LinearSolver):
             The results dictionary from compute method.
         :param broadening_type:
             The type of broadening to use. Either 'lorentzian' or 'gaussian'.
-        :param broadening_value:
+        :param broadening_value_ev:
             The broadening value, FWHM in eV.
         :param x_unit:
             Unit for the x-axis.
-        :param x_step:
+        :param xstep:
             Grid spacing in eV for the broadened RIXS spectrum.
         :param energy_loss:
             If True, plot versus energy loss.
@@ -1123,7 +1139,7 @@ class RixsDriver(LinearSolver):
             broadening_value=broadening_value_ev,
             photon_index=photon_index,
             x_unit=x_unit,
-            x_step=x_step,
+            xstep=xstep,
             energy_loss=energy_loss,
             ax=ax
         )
@@ -1132,7 +1148,7 @@ class RixsDriver(LinearSolver):
                  results,
                  broadening_type="lorentzian",
                  broadening_value_ev=0.24,
-                 x_step=1e-2,
+                 xstep=1e-2,
                  x_unit='ev',
                  energy_loss=True,
                  min_photon_points=10,
@@ -1148,7 +1164,7 @@ class RixsDriver(LinearSolver):
             The type of broadening to use. Either 'lorentzian' or 'gaussian'.
         :param broadening_value_ev:
             The broadening value, FWHM in eV.
-        :param x_step:
+        :param xstep:
             Grid spacing in eV for the broadened RIXS map.
         :param x_unit:
             Currently only 'ev' is supported.
@@ -1180,7 +1196,7 @@ class RixsDriver(LinearSolver):
             results,
             broadening_type=broadening_type,
             broadening_value=broadening_value_ev,
-            x_step=x_step,
+            xstep=xstep,
             x_unit=x_unit,
             energy_loss=energy_loss,
             cmap=colormap,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1105,7 +1105,8 @@ class RixsDriver(LinearSolver):
         :param broadening_value_ev:
             The broadening value, FWHM in eV.
         :param x_unit:
-            Unit for the x-axis.
+            Unit for the x-axis. Currently only 'ev' is supported.
+            NOTE: does not affect other inputs, which are expected to be in eV.
         :param xstep:
             Grid spacing in eV for the broadened RIXS spectrum.
         :param energy_loss:
@@ -1172,7 +1173,8 @@ class RixsDriver(LinearSolver):
         :param xstep:
             Grid spacing in eV for the broadened RIXS map.
         :param x_unit:
-            Currently only 'ev' is supported.
+            Unit for the x-axis. Currently only 'ev' is supported.
+            NOTE: does not affect other inputs, which are expected to be in eV.
         :param energy_loss:
             If True, plot versus energy loss.
             If False, plot versus emission energy.

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1132,7 +1132,7 @@ class RixsDriver(LinearSolver):
                  results,
                  broadening_type="lorentzian",
                  broadening_value_ev=0.24,
-                 x_step=1e-3,
+                 x_step=1e-2,
                  x_unit='ev',
                  energy_loss=True,
                  min_photon_points=10,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1074,7 +1074,7 @@ class RixsDriver(LinearSolver):
              broadening_type="lorentzian",
              broadening_value_ev=0.24,
              x_unit='ev',
-             x_step=1e-3,
+             x_step=1e-4,
              energy_loss=True,
              photon_energy_ev=None,
              ax=None):
@@ -1132,7 +1132,7 @@ class RixsDriver(LinearSolver):
                  results,
                  broadening_type="lorentzian",
                  broadening_value_ev=0.24,
-                 x_step=1e-3,
+                 x_step=1e-4,
                  x_unit='ev',
                  energy_loss=True,
                  min_photon_points=10,

--- a/src/pymodule/rixsdriver.py
+++ b/src/pymodule/rixsdriver.py
@@ -1132,7 +1132,7 @@ class RixsDriver(LinearSolver):
                  results,
                  broadening_type="lorentzian",
                  broadening_value_ev=0.24,
-                 x_step=1e-4,
+                 x_step=1e-3,
                  x_unit='ev',
                  energy_loss=True,
                  min_photon_points=10,

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -599,7 +599,7 @@ def plot_rixs_spectrum(rixs_results,
 
     omega_ev = incoming_ev[photon_index]
 
-    ax.set_ylabel(r'Cross section, $\sigma$ [$a_0^2$]')
+    ax.set_ylabel(r'Cross section, $\sigma$ [a.u.]')
     ax.set_title(rf"RIXS Spectrum @ $\hbar \omega = {omega_ev:.2f}$ eV")
 
     if energy_loss:
@@ -620,7 +620,7 @@ def plot_rixs_spectrum(rixs_results,
 
     ax2 = ax.twinx()
     ax2.set_ylabel(
-        r'Intensity, $ \text{d} \sigma / \text{d} \omega $ [$a_0^2$ eV$^{-1}$]'
+        r'Intensity [arb. units]'
         )
     
 
@@ -689,10 +689,10 @@ def plot_rixs_spectrum(rixs_results,
                bbox_to_anchor=(1.15, 0.5))
 
     ax.set_ylim(0, max(abs(y)) * 1.1)
-    ax.set_ylim(bottom=0)
+    ax.set_ylim(bottom=-0.02 * max(abs(y)))
 
     ax2.set_ylim(0, max(xsection) * 1.1)
-    ax2.set_ylim(bottom=0)
+    ax2.set_ylim(bottom=-0.02 * max(abs(xsection)))
 
     if use_ev:
         x_lim = (xmin_ev, xmax_ev)
@@ -714,6 +714,7 @@ def plot_rixs_map(rixs_results,
                   x_step=0.01,
                   x_unit="ev",
                   cmap='viridis',
+                  normalize='global_max',
                   ax=None):
     """
     Plot a 2D RIXS map together with the corresponding XAS.
@@ -756,7 +757,7 @@ def plot_rixs_map(rixs_results,
         ax_map, ax_xas = ax
         fig = ax_map.figure
 
-    incoming_ev = np.array(rixs_results['elastic_emission']) * au2ev
+    incoming_photon_energies_ev = np.array(rixs_results['elastic_emission']) * au2ev
     core_eigvals_ev = np.array(rixs_results['core_eigenvalues']) * au2ev
     gamma_fwhm_ev = float(rixs_results['gamma_fwhm_ev'])
     core_osc_strs = np.array(rixs_results['core_osc_strengths'])
@@ -774,8 +775,8 @@ def plot_rixs_map(rixs_results,
         'plot_rixs_map: number of core eigenvalues does not match oscillator strengths.'
     )
 
-    sort_idx = np.argsort(incoming_ev)
-    incoming_ev = incoming_ev[sort_idx]
+    sort_idx = np.argsort(incoming_photon_energies_ev)
+    incoming_photon_energies_ev = incoming_photon_energies_ev[sort_idx]
     x_ev = x_ev[:, sort_idx]
     cross_sections = cross_sections[:, sort_idx]
 
@@ -794,12 +795,12 @@ def plot_rixs_map(rixs_results,
         val_min_ev = xmin_ev - pad
         val_max_ev = xmax_ev + pad
 
-    n_photons = incoming_ev.size
+    nr_incoming_photons = incoming_photon_energies_ev.size
 
     xi = None
     rixs_map = None
 
-    for i in range(n_photons):
+    for i in range(nr_incoming_photons):
 
         if broadening_type.lower() == "lorentzian":
             xi_tmp, yi_tmp = lorentzian_xps(
@@ -826,7 +827,7 @@ def plot_rixs_map(rixs_results,
 
         if xi is None:
             xi = xi_tmp
-            rixs_map = np.zeros((len(xi), n_photons))
+            rixs_map = np.zeros((len(xi), nr_incoming_photons))
 
         assert_msg_critical(
             len(xi_tmp) == len(xi),
@@ -836,15 +837,34 @@ def plot_rixs_map(rixs_results,
         rixs_map[:, i] = yi_tmp
 
     # rows = incoming photon energies, cols = loss/emission
-    Z = rixs_map.T
+    rixs_map_T = rixs_map.T
 
-    ymin_map = incoming_ev.min()
-    ymax_map = incoming_ev.max()
+    if normalize is not None and normalize is not False:
+        normalize = normalize.lower()
+
+        if normalize == 'global_max':
+            max_intensity = np.max(rixs_map_T)
+
+            assert_msg_critical(
+                max_intensity > 0.0,
+                'plot_rixs_map: Cannot normalize RIXS map because maximum intensity is zero.'
+            )
+
+            rixs_map_T /= max_intensity
+
+        else:
+            assert_msg_critical(
+                False,
+                'plot_rixs_map: Invalid normalize option. Use None or "global_max".'
+            )
+
+    ymin_map = incoming_photon_energies_ev.min()
+    ymax_map = incoming_photon_energies_ev.max()
 
     limits = [xi.min(), xi.max(), ymin_map, ymax_map]
 
     im = ax_map.imshow(
-        Z,
+        rixs_map_T,
         extent=limits,
         origin='lower',
         aspect='auto',
@@ -876,7 +896,7 @@ def plot_rixs_map(rixs_results,
     offset_text.set_ha('left')
 
     cbar.set_label(
-        r'Intensity, $ \text{d} \sigma / \text{d} \omega $ [$a_0^2$ eV$^{-1}$]'
+        r'Intensity [arb. units]'
     )
 
     if energy_loss:
@@ -918,7 +938,7 @@ def plot_rixs_map(rixs_results,
 
     ax_xas.plot(xas_y, xas_x, lw=2.5, color='black')
     ax_xas.fill_betweenx(xas_x, 0.0, xas_y, alpha=0.2, color='black')
-    ax_xas.barh(core_eigvals_ev, core_osc_strs, height=0.025, color='darkcyan', alpha=0.7)
+    ax_xas.barh(core_eigvals_ev, core_osc_strs, height=0.05, color='darkcyan', alpha=0.7)
 
     ax_xas.set_title('XAS')
     ax_xas.set_xlabel('Intensity')

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -897,7 +897,7 @@ def plot_rixs_map(rixs_results,
     offset_text.set_ha('left')
 
     cbar.set_label(
-        r'Normalized intensity [arb. units]'
+        r'Intensity [arb. units]'
     )
 
     if energy_loss:

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -534,9 +534,9 @@ def plot_xps_spectrum(xps_results,
 
     return ax
 
+
 def plot_rixs_spectrum(rixs_results,
                        photon_index=0,
-                       photon_energy=None,
                        energy_loss=True,
                        broadening_type="lorentzian",
                        broadening_value=0.24,
@@ -550,11 +550,8 @@ def plot_rixs_spectrum(rixs_results,
         The dictionary containing the RIXS results.
     :param photon_index:
         The index of the incoming photon to plot the spectrum for. (0-based)
-    :param photon_energy:
-        Incoming photon energy in eV. If given, the closest available
-        incoming photon energy is used instead of photon_index.
     :param energy_loss:
-        If True, plot the spectrum as a function of energy loss. 
+        If True, plot the spectrum as a function of energy loss.
         If False, plot as a function of emission energy.
     :param broadening_type:
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
@@ -573,14 +570,12 @@ def plot_rixs_spectrum(rixs_results,
     ev_x_nm = hartree_in_ev() / hartree_in_inverse_nm()
     au2ev = hartree_in_ev()
 
-    incoming_ev = np.asarray(rixs_results['elastic_emission']) * au2ev
-
-    if photon_energy is not None:
-        photon_index = int(np.argmin(np.abs(incoming_ev - photon_energy)))
+    # incoming photon energies in eV
+    incoming_ev = np.asarray(rixs_results['photon_energies']) * au2ev
 
     assert_msg_critical(
         photon_index >= 0 and photon_index < incoming_ev.size,
-        'plot: photon_index out of range.'
+        'plot: index of incoming photon energy (photon_index) out of range.'
     )
 
     if ax is None:
@@ -599,7 +594,7 @@ def plot_rixs_spectrum(rixs_results,
 
     omega_ev = incoming_ev[photon_index]
 
-    ax.set_ylabel(r'Cross section, $\sigma$ [a.u.]')
+    ax.set_ylabel(r'Normalized intensity [arb. units]')
     ax.set_title(rf"RIXS Spectrum @ $\hbar \omega = {omega_ev:.2f}$ eV")
 
     if energy_loss:
@@ -619,10 +614,7 @@ def plot_rixs_spectrum(rixs_results,
     xstep_ev = xstep * au2ev
 
     ax2 = ax.twinx()
-    ax2.set_ylabel(
-        r'Intensity [arb. units]'
-        )
-    
+    ax2.set_ylabel(r'Cross section, $\sigma$ [a.u.]')
 
     for i in np.arange(len(y)):
         if energy_loss:
@@ -637,7 +629,7 @@ def plot_rixs_spectrum(rixs_results,
         else:
             x_val = ev_x_nm / energy_ev
 
-        ax.plot(
+        ax2.plot(
             [x_val, x_val],
             [0.0, rixs_results['cross_sections'][i, photon_index]],
             alpha=0.7,
@@ -658,14 +650,22 @@ def plot_rixs_spectrum(rixs_results,
     else:
         assert_msg_critical(False, 'plot: Invalid broadening_type')
 
-    xsection = yi
+    # Normalize to maximum
+    max_intensity = np.max(yi)
+
+    assert_msg_critical(
+        max_intensity > 0.0,
+        'plot_rixs_spectrum: Cannot normalize RIXS map because maximum intensity is zero.'
+    )
+
+    norm_intensity = yi / max_intensity
 
     if use_ev:
         x_data = xi
     else:
         x_data = ev_x_nm / xi
 
-    ax2.plot(x_data, xsection, color="black", alpha=0.9, linewidth=2.5)
+    ax.plot(x_data, norm_intensity, color="black", alpha=0.9, linewidth=2.5)
 
     legend_bars = mlines.Line2D([], [],
                                 color='darkcyan',
@@ -688,11 +688,11 @@ def plot_rixs_spectrum(rixs_results,
                loc='center left',
                bbox_to_anchor=(1.15, 0.5))
 
-    ax.set_ylim(0, max(abs(y)) * 1.1)
-    ax.set_ylim(bottom=-0.02 * max(abs(y)))
+    ax2.set_ylim(0, max(abs(y)) * 1.1)
+    ax2.set_ylim(bottom=-0.02 * max(abs(y)))
 
-    ax2.set_ylim(0, max(xsection) * 1.1)
-    ax2.set_ylim(bottom=-0.02 * max(abs(xsection)))
+    ax.set_ylim(0, max(norm_intensity) * 1.1)
+    ax.set_ylim(bottom=-0.02 * max(abs(norm_intensity)))
 
     if use_ev:
         x_lim = (xmin_ev, xmax_ev)
@@ -706,6 +706,7 @@ def plot_rixs_spectrum(rixs_results,
     ax2.set_xlim(x_lim)
 
     return ax
+
 
 def plot_rixs_map(rixs_results,
                   energy_loss=True,
@@ -757,7 +758,7 @@ def plot_rixs_map(rixs_results,
         ax_map, ax_xas = ax
         fig = ax_map.figure
 
-    incoming_photon_energies_ev = np.array(rixs_results['elastic_emission']) * au2ev
+    incoming_photon_energies_ev = np.array(rixs_results['photon_energies']) * au2ev
     core_eigvals_ev = np.array(rixs_results['core_eigenvalues']) * au2ev
     gamma_fwhm_ev = float(rixs_results['gamma_fwhm_ev'])
     core_osc_strs = np.array(rixs_results['core_osc_strengths'])
@@ -896,7 +897,7 @@ def plot_rixs_map(rixs_results,
     offset_text.set_ha('left')
 
     cbar.set_label(
-        r'Intensity [arb. units]'
+        r'Normalized intensity [arb. units]'
     )
 
     if energy_loss:
@@ -946,8 +947,8 @@ def plot_rixs_map(rixs_results,
     ax_xas.set_xlim(left=0.0)
     ax_xas.set_xticks([])
 
-    ax_map.set_ylim(ymin_map, ymax_map) #- 0.2
-    ax_xas.set_ylim(ymin_map, ymax_map) #+ 0.2
+    ax_map.set_ylim(ymin_map, ymax_map)
+    ax_xas.set_ylim(ymin_map, ymax_map)
     ax_map.tick_params(axis='both', which='both',
                        direction='out',
                        bottom=True, top=False,
@@ -963,6 +964,7 @@ def plot_rixs_map(rixs_results,
                        labelleft=False, labelright=False)
 
     return ax_map, ax_xas
+
 
 def plot_tpa_transition_spectrum(rsp_results,
                                  spectrum,

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -538,8 +538,7 @@ def plot_rixs_spectrum(rixs_results,
                        photon_index=0,
                        energy_loss=True,
                       broadening_type="lorentzian",
-                      broadening_value=(1000.0 / hartree_in_wavenumber() *
-                                        hartree_in_ev()),
+                      broadening_value=0.15,
                         x_unit="ev",
                       ax=None):
     """
@@ -547,6 +546,11 @@ def plot_rixs_spectrum(rixs_results,
 
     :param rixs_results:
         The dictionary containing the RIXS results.
+    :param photon_index:
+        The index of the incoming photon to plot the spectrum for. (0-based)
+    :param energy_loss:
+        If True, plot the spectrum as a function of energy loss. 
+        If False, plot as a function of emission energy.
     :param broadening_type:
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
@@ -554,117 +558,140 @@ def plot_rixs_spectrum(rixs_results,
     :param ax:
         The matplotlib axis to plot on.
     """
-
     assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
-
     assert_msg_critical(x_unit.lower() in ['nm', 'ev'], 'plot: Invalid x_unit')
 
     use_ev = (x_unit.lower() == 'ev')
 
     ev_x_nm = hartree_in_ev() / hartree_in_inverse_nm()
     au2ev = hartree_in_ev()
-    ev2au = 1.0 / au2ev
 
-    # initialize the plot
     if ax is None:
         fig, ax = plt.subplots(figsize=(8, 5))
 
     if energy_loss:
         if use_ev:
-            ax.set_xlabel('Energy-loss [eV]')
+            ax.set_xlabel('Energy loss [eV]')
         else:
-            ax.set_xlabel('Energy-loss [nm]')
+            ax.set_xlabel('Energy loss [nm]')
     else:
         if use_ev:
             ax.set_xlabel('Emission energy [eV]')
         else:
             ax.set_xlabel('Emission energy [nm]')
-    ax.set_ylabel(r'$\sigma$ [a.u.]')
 
+    ax.set_ylabel(r'Reduced cross section, $\sigma/r_e^2$')
     ax.set_title("RIXS Spectrum")
 
+    omega_ev = rixs_results['elastic_emission'][photon_index] * au2ev
+
+    ax.text(
+        0.03, 0.95,
+        rf'$\hbar \omega = {omega_ev:.2f}$ eV',
+        transform=ax.transAxes,
+        ha='left',
+        va='top'
+    )
+
     if energy_loss:
-        x = (rixs_results['energy_losses'][:,photon_index])
+        x = rixs_results['energy_losses'][:, photon_index]
     else:
-        x = (rixs_results['emission_energies'][:,photon_index])
-    y = rixs_results['cross_sections'][:,photon_index]
+        x = rixs_results['emission_energies'][:, photon_index]
+
+    y = rixs_results['cross_sections'][:, photon_index]
+
     xmin = max(0.0, min(x) - 0.03)
     xmax = max(x) + 0.03
     xstep = 0.0001
 
-    ax2 = ax.twinx()
+    x_ev = x * au2ev
+    xmin_ev = xmin * au2ev
+    xmax_ev = xmax * au2ev
+    xstep_ev = xstep * au2ev
 
-    for i in np.arange(len(rixs_results['cross_sections'][:,photon_index])):
+    ax2 = ax.twinx()
+    ax2.set_ylabel(r'Intensity, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]')
+
+    for i in np.arange(len(y)):
         if energy_loss:
-            if use_ev:
-                x_val = rixs_results['energy_losses'][i,photon_index] * au2ev,
-            else:
-                x_val = ev_x_nm / (rixs_results['energy_losses'][i,photon_index] * au2ev)
+            energy_au = rixs_results['energy_losses'][i, photon_index]
         else:
-            if use_ev:
-                x_val = rixs_results['emission_energies'][i,photon_index] * au2ev,
-            else:
-                x_val = ev_x_nm / (rixs_results['emission_energies'][i,photon_index] * au2ev)
-        ax2.plot(
+            energy_au = rixs_results['emission_energies'][i, photon_index]
+
+        energy_ev = energy_au * au2ev
+
+        if use_ev:
+            x_val = energy_ev
+        else:
+            x_val = ev_x_nm / energy_ev
+
+        ax.plot(
             [x_val, x_val],
-            [0.0, rixs_results['cross_sections'][i,photon_index]],
+            [0.0, rixs_results['cross_sections'][i, photon_index]],
             alpha=0.7,
             linewidth=2,
             color="darkcyan",
         )
 
-    c = 1.0 / fine_structure_constant()
-    NA = avogadro_constant()
-    a_0 = bohr_in_angstrom() * 1.0e-10
-
     if broadening_type.lower() == "lorentzian":
-        xi, yi = lorentzian_absorption(x, y, xmin, xmax, xstep,
-                                       broadening_value * ev2au)
+        xi, yi = lorentzian_xps(
+            x_ev, y, xmin_ev, xmax_ev, xstep_ev, broadening_value
+        )
 
     elif broadening_type.lower() == "gaussian":
-        xi, yi = gaussian_absorption(x, y, xmin, xmax, xstep,
-                                     broadening_value * ev2au)
+        xi, yi = gaussian_xps(
+            x_ev, y, xmin_ev, xmax_ev, xstep_ev, broadening_value
+        )
+
+    else:
+        assert_msg_critical(False, 'plot: Invalid broadening_type')
 
     xsection = yi
 
     if use_ev:
-        x_data = xi * au2ev
+        x_data = xi
     else:
-        x_data = ev_x_nm / (xi * au2ev)
-    ax.plot(x_data, xsection, color="black", alpha=0.9, linewidth=2.5)
+        x_data = ev_x_nm / xi
+
+    ax2.plot(x_data, xsection, color="black", alpha=0.9, linewidth=2.5)
 
     legend_bars = mlines.Line2D([], [],
                                 color='darkcyan',
                                 alpha=0.7,
                                 linewidth=2,
-                                label='Cross sections')
+                                label='Cross section')
+
     label_spectrum = f'{broadening_type.capitalize()} '
     label_spectrum += f'broadening ({broadening_value:.3f} eV)'
+
     legend_spectrum = mlines.Line2D([], [],
                                     color='black',
                                     linestyle='-',
                                     linewidth=2.5,
                                     label=label_spectrum)
+
     ax2.legend(handles=[legend_bars, legend_spectrum],
-               frameon=False,
-               borderaxespad=0.,
-               loc='center left',
-               bbox_to_anchor=(1.15, 0.5))
-    ax2.set_ylim(0, max(abs(rixs_results['cross_sections'][:, photon_index])) * 1.1)
-    ax.set_ylim(0, max(xsection) * 1.1)
+            frameon=False,
+            borderaxespad=0.,
+            loc='center left',
+            bbox_to_anchor=(1.15, 0.5))
+
+    ax.set_ylim(0, max(abs(y)) * 1.1)
     ax.set_ylim(bottom=0)
+
+    ax2.set_ylim(0, max(xsection) * 1.1)
     ax2.set_ylim(bottom=0)
-    ax2.set_ylabel("Cross sections")
 
     if use_ev:
-        x_lim = (xmin * au2ev, xmax * au2ev)
+        x_lim = (xmin_ev, xmax_ev)
     else:
-        x_lim = (ev_x_nm / (xmax * au2ev), ev_x_nm / (xmin * au2ev))
+        x_lim = (ev_x_nm / xmax_ev, ev_x_nm / xmin_ev)
 
     if energy_loss:
         x_lim = x_lim[::-1]
 
     ax.set_xlim(x_lim)
+    ax2.set_xlim(x_lim)
 
 
 def plot_tpa_transition_spectrum(rsp_results,

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -538,7 +538,7 @@ def plot_rixs_spectrum(rixs_results,
                        photon_index=0,
                        energy_loss=True,
                       broadening_type="lorentzian",
-                      broadening_value=0.15,
+                      broadening_value=0.24,
                         x_unit="ev",
                       ax=None):
     """
@@ -554,7 +554,7 @@ def plot_rixs_spectrum(rixs_results,
     :param broadening_type:
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
-        The broadening value in eV.
+        The FWHM in eV.
     :param ax:
         The matplotlib axis to plot on.
     """

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -534,6 +534,138 @@ def plot_xps_spectrum(xps_results,
 
     return ax
 
+def plot_rixs_spectrum(rixs_results,
+                       photon_index=0,
+                       energy_loss=True,
+                      broadening_type="lorentzian",
+                      broadening_value=(1000.0 / hartree_in_wavenumber() *
+                                        hartree_in_ev()),
+                        x_unit="ev",
+                      ax=None):
+    """
+    Plot the RIXS spectrum from a RIXS calculation.
+
+    :param rixs_results:
+        The dictionary containing the RIXS results.
+    :param broadening_type:
+        The type of broadening to use. Either 'lorentzian' or 'gaussian'.
+    :param broadening_value:
+        The broadening value in eV.
+    :param ax:
+        The matplotlib axis to plot on.
+    """
+
+    assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
+
+    assert_msg_critical(x_unit.lower() in ['nm', 'ev'], 'plot: Invalid x_unit')
+
+    use_ev = (x_unit.lower() == 'ev')
+
+    ev_x_nm = hartree_in_ev() / hartree_in_inverse_nm()
+    au2ev = hartree_in_ev()
+    ev2au = 1.0 / au2ev
+
+    # initialize the plot
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(8, 5))
+
+    if energy_loss:
+        if use_ev:
+            ax.set_xlabel('Energy-loss [eV]')
+        else:
+            ax.set_xlabel('Energy-loss [nm]')
+    else:
+        if use_ev:
+            ax.set_xlabel('Emission energy [eV]')
+        else:
+            ax.set_xlabel('Emission energy [nm]')
+    ax.set_ylabel(r'$\sigma$ [a.u.]')
+
+    ax.set_title("RIXS Spectrum")
+
+    if energy_loss:
+        x = (rixs_results['energy_losses'][:,photon_index])
+    else:
+        x = (rixs_results['emission_energies'][:,photon_index])
+    y = rixs_results['cross_sections'][:,photon_index]
+    xmin = max(0.0, min(x) - 0.03)
+    xmax = max(x) + 0.03
+    xstep = 0.0001
+
+    ax2 = ax.twinx()
+
+    for i in np.arange(len(rixs_results['cross_sections'][:,photon_index])):
+        if energy_loss:
+            if use_ev:
+                x_val = rixs_results['energy_losses'][i,photon_index] * au2ev,
+            else:
+                x_val = ev_x_nm / (rixs_results['energy_losses'][i,photon_index] * au2ev)
+        else:
+            if use_ev:
+                x_val = rixs_results['emission_energies'][i,photon_index] * au2ev,
+            else:
+                x_val = ev_x_nm / (rixs_results['emission_energies'][i,photon_index] * au2ev)
+        ax2.plot(
+            [x_val, x_val],
+            [0.0, rixs_results['cross_sections'][i,photon_index]],
+            alpha=0.7,
+            linewidth=2,
+            color="darkcyan",
+        )
+
+    c = 1.0 / fine_structure_constant()
+    NA = avogadro_constant()
+    a_0 = bohr_in_angstrom() * 1.0e-10
+
+    if broadening_type.lower() == "lorentzian":
+        xi, yi = lorentzian_absorption(x, y, xmin, xmax, xstep,
+                                       broadening_value * ev2au)
+
+    elif broadening_type.lower() == "gaussian":
+        xi, yi = gaussian_absorption(x, y, xmin, xmax, xstep,
+                                     broadening_value * ev2au)
+
+    xsection = yi
+
+    if use_ev:
+        x_data = xi * au2ev
+    else:
+        x_data = ev_x_nm / (xi * au2ev)
+    ax.plot(x_data, xsection, color="black", alpha=0.9, linewidth=2.5)
+
+    legend_bars = mlines.Line2D([], [],
+                                color='darkcyan',
+                                alpha=0.7,
+                                linewidth=2,
+                                label='Cross sections')
+    label_spectrum = f'{broadening_type.capitalize()} '
+    label_spectrum += f'broadening ({broadening_value:.3f} eV)'
+    legend_spectrum = mlines.Line2D([], [],
+                                    color='black',
+                                    linestyle='-',
+                                    linewidth=2.5,
+                                    label=label_spectrum)
+    ax2.legend(handles=[legend_bars, legend_spectrum],
+               frameon=False,
+               borderaxespad=0.,
+               loc='center left',
+               bbox_to_anchor=(1.15, 0.5))
+    ax2.set_ylim(0, max(abs(rixs_results['cross_sections'][:, photon_index])) * 1.1)
+    ax.set_ylim(0, max(xsection) * 1.1)
+    ax.set_ylim(bottom=0)
+    ax2.set_ylim(bottom=0)
+    ax2.set_ylabel("Cross sections")
+
+    if use_ev:
+        x_lim = (xmin * au2ev, xmax * au2ev)
+    else:
+        x_lim = (ev_x_nm / (xmax * au2ev), ev_x_nm / (xmin * au2ev))
+
+    if energy_loss:
+        x_lim = x_lim[::-1]
+
+    ax.set_xlim(x_lim)
+
 
 def plot_tpa_transition_spectrum(rsp_results,
                                  spectrum,

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -1059,8 +1059,19 @@ def plot_rixs_map(rixs_results,
     ])
 
     cbar = fig.colorbar(im, cax=cax)
+
+    cbar.ax.ticklabel_format(
+        axis='y',
+        style='sci',
+        scilimits=(0, 0),
+        useMathText=True
+    )
+
+    offset_text = cbar.ax.yaxis.get_offset_text()
+    offset_text.set_ha('left')
+
     cbar.set_label(
-        r'Cross section, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]'
+        r'Intensity, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]'
     )
 
     if energy_loss:

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -541,6 +541,7 @@ def plot_rixs_spectrum(rixs_results,
                        broadening_type="lorentzian",
                        broadening_value=0.24,
                        x_unit="ev",
+                       x_step=0.01,
                        ax=None):
     """
     Plot the RIXS spectrum from a RIXS calculation.
@@ -559,6 +560,8 @@ def plot_rixs_spectrum(rixs_results,
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
         The FWHM in eV.
+    :param x_step:
+        Grid spacing in eV for the broadened RIXS spectrum.
     :param ax:
         The matplotlib axis to plot on.
     """
@@ -596,7 +599,7 @@ def plot_rixs_spectrum(rixs_results,
 
     omega_ev = incoming_ev[photon_index]
 
-    ax.set_ylabel(r'Reduced cross section, $\sigma/r_e^2$')
+    ax.set_ylabel(r'Cross section, $\sigma$ [$a_0^2$]')
     ax.set_title(rf"RIXS Spectrum @ $\hbar \omega = {omega_ev:.2f}$ eV")
 
     if energy_loss:
@@ -608,7 +611,7 @@ def plot_rixs_spectrum(rixs_results,
 
     xmin = max(0.0, min(x) - 0.03)
     xmax = max(x) + 0.03
-    xstep = 0.0001
+    xstep = x_step
 
     x_ev = x * au2ev
     xmin_ev = xmin * au2ev
@@ -616,7 +619,10 @@ def plot_rixs_spectrum(rixs_results,
     xstep_ev = xstep * au2ev
 
     ax2 = ax.twinx()
-    ax2.set_ylabel(r'Intensity, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]')
+    ax2.set_ylabel(
+        r'Intensity, $ \text{d} \sigma / \text{d} \omega $ [$a_0^2$ eV$^{-1}$]'
+        )
+    
 
     for i in np.arange(len(y)):
         if energy_loss:
@@ -698,207 +704,6 @@ def plot_rixs_spectrum(rixs_results,
 
     ax.set_xlim(x_lim)
     ax2.set_xlim(x_lim)
-
-    return ax
-
-def plot_rixs_slices(rixs_results,
-                     photon_indices,
-                     energy_loss=True,
-                     broadening_type="lorentzian",
-                     broadening_value=0.24,
-                     x_step=0.01,
-                     x_unit="ev",
-                     normalize=True,
-                     ax=None):
-    """
-    Plot several RIXS spectra as stacked 1D slices.
-
-    :param rixs_results:
-        The dictionary containing the RIXS results.
-    :param photon_indices:
-        List of incoming photon indices to plot.
-    :param energy_loss:
-        If True, plot as a function of energy loss.
-        If False, plot as a function of emission energy.
-    :param broadening_type:
-        The type of broadening to use. Either 'lorentzian' or 'gaussian'.
-    :param broadening_value:
-        The FWHM in eV.
-    :param x_step:
-        Grid spacing in eV for the broadened spectra.
-    :param x_unit:
-        Only 'ev' is supported.
-    :param normalize:
-        If True, normalize all broadened spectra by the global maximum.
-    :param ax:
-        The matplotlib axis to plot on.
-    """
-
-    assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
-    assert_msg_critical(x_unit.lower() == 'ev',
-                        'plot_rixs_slices: only x_unit="ev" is currently supported.')
-
-    au2ev = hartree_in_ev()
-
-    if ax is None:
-        fig, ax = plt.subplots(figsize=(8, 6))
-
-    photon_indices = np.asarray(photon_indices, dtype=int)
-
-    incoming_ev = np.asarray(rixs_results['elastic_emission']) * au2ev
-    cross_sections = np.asarray(rixs_results['cross_sections'])
-
-    if energy_loss:
-        x_au = np.asarray(rixs_results['energy_losses'])
-        ax.set_xlabel('Energy loss [eV]')
-    else:
-        x_au = np.asarray(rixs_results['emission_energies'])
-        ax.set_xlabel('Emission energy [eV]')
-
-    x_ev = x_au * au2ev
-
-    assert_msg_critical(
-        x_ev.shape == cross_sections.shape,
-        'plot_rixs_slices: x values and cross sections have incompatible shapes.'
-    )
-
-    assert_msg_critical(
-        np.all(photon_indices >= 0) and np.all(photon_indices < incoming_ev.size),
-        'plot_rixs_slices: photon_index out of range.'
-    )
-
-    sort_idx = np.argsort(incoming_ev[photon_indices])
-    photon_indices = photon_indices[sort_idx]
-
-    x_sel = x_ev[:, photon_indices]
-    y_sel = cross_sections[:, photon_indices]
-    incoming_sel_ev = incoming_ev[photon_indices]
-
-    x_sel = x_ev[:, photon_indices]
-    y_sel = cross_sections[:, photon_indices]
-    incoming_sel_ev = incoming_ev[photon_indices]
-
-    # pad x-range to ensure broadened spectra are not cut off at the edges
-    x_pad = max(0.25, 2.0 * broadening_value)
-
-    xmin_ev = np.min(x_sel) - x_pad
-    xmax_ev = np.max(x_sel) + x_pad
-
-    if energy_loss:
-        xmin_ev = max(0.0, xmin_ev)
-
-    spectra = []
-    xi = None
-
-    for col in range(len(photon_indices)):
-
-        if broadening_type.lower() == "lorentzian":
-            xi_tmp, yi_tmp = lorentzian_xps(
-                x_sel[:, col],
-                y_sel[:, col],
-                xmin_ev,
-                xmax_ev,
-                x_step,
-                broadening_value
-            )
-
-        elif broadening_type.lower() == "gaussian":
-            xi_tmp, yi_tmp = gaussian_xps(
-                x_sel[:, col],
-                y_sel[:, col],
-                xmin_ev,
-                xmax_ev,
-                x_step,
-                broadening_value
-            )
-
-        else:
-            assert_msg_critical(False, 'plot_rixs_slices: Invalid broadening_type')
-
-        if xi is None:
-            xi = xi_tmp
-
-        spectra.append(yi_tmp)
-
-    spectra = np.asarray(spectra)
-
-    # normalize all spectra by the global maximum if requested
-    if normalize:
-        max_intensity = np.max(np.abs(spectra))
-
-        if max_intensity > 0.0:
-            spectra = spectra / max_intensity
-    else:
-        max_intensity = 1.0
-
-    stick_heights = np.array(y_sel, copy=True)
-
-    if normalize:
-        max_stick = np.max(np.abs(stick_heights))
-
-        if max_stick > 0.0:
-            stick_heights = stick_heights / max_stick
-
-    offset = 1.2
-
-    for i, omega_ev in enumerate(incoming_sel_ev):
-        y_offset = i * offset
-
-        for k in range(x_sel.shape[0]):
-            ax.plot(
-                [x_sel[k, i], x_sel[k, i]],
-                [y_offset, y_offset + stick_heights[k, i]],
-                alpha=0.7,
-                linewidth=2,
-                color="darkcyan",
-            )
-
-        ax.plot(
-            xi,
-            spectra[i] + y_offset,
-            color='black',
-            linewidth=2.0
-        )
-
-    if energy_loss:
-        ax.set_xlim(xi.max(), xi.min())
-    else:
-        ax.set_xlim(xi.min(), xi.max())
-
-    ax.set_ylabel('Incoming photon energy [eV]')
-    ax.set_yticks(np.arange(len(incoming_sel_ev)) * offset)
-    ax.set_yticklabels([f'{omega:.2f}' for omega in incoming_sel_ev])
-
-    label_spectrum = f'{broadening_type.capitalize()} '
-    label_spectrum += f'broadening ({broadening_value:.3f} eV)'
-    title_spectrum = 'RIXS Spectra'
-
-    ax.set_title(title_spectrum)
-
-    ax.tick_params(axis='both', which='both',
-                   direction='out',
-                   bottom=True, top=False,
-                   left=True, right=False,
-                   labelbottom=True, labeltop=False,
-                   labelleft=True, labelright=False)
-
-    legend_bars = mlines.Line2D([], [],
-                                color='darkcyan',
-                                alpha=0.7,
-                                linewidth=2,
-                                label='Cross section')
-
-    legend_spectrum = mlines.Line2D([], [],
-                                    color='black',
-                                    linestyle='-',
-                                    linewidth=2.5,
-                                    label=label_spectrum)
-
-    ax.legend(handles=[legend_bars, legend_spectrum],
-              frameon=False,
-              borderaxespad=0.,
-              loc='center left',
-              bbox_to_anchor=(1.05, 0.5))
 
     return ax
 
@@ -1071,7 +876,7 @@ def plot_rixs_map(rixs_results,
     offset_text.set_ha('left')
 
     cbar.set_label(
-        r'Intensity, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]'
+        r'Intensity, $ \text{d} \sigma / \text{d} \omega $ [$a_0^2$ eV$^{-1}$]'
     )
 
     if energy_loss:
@@ -1136,7 +941,6 @@ def plot_rixs_map(rixs_results,
                        left=False, right=False,
                        labelbottom=False, labeltop=False,
                        labelleft=False, labelright=False)
-    
 
     return ax_map, ax_xas
 

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -536,11 +536,12 @@ def plot_xps_spectrum(xps_results,
 
 def plot_rixs_spectrum(rixs_results,
                        photon_index=0,
+                       photon_energy=None,
                        energy_loss=True,
-                      broadening_type="lorentzian",
-                      broadening_value=0.24,
-                        x_unit="ev",
-                      ax=None):
+                       broadening_type="lorentzian",
+                       broadening_value=0.24,
+                       x_unit="ev",
+                       ax=None):
     """
     Plot the RIXS spectrum from a RIXS calculation.
 
@@ -548,6 +549,9 @@ def plot_rixs_spectrum(rixs_results,
         The dictionary containing the RIXS results.
     :param photon_index:
         The index of the incoming photon to plot the spectrum for. (0-based)
+    :param photon_energy:
+        Incoming photon energy in eV. If given, the closest available
+        incoming photon energy is used instead of photon_index.
     :param energy_loss:
         If True, plot the spectrum as a function of energy loss. 
         If False, plot as a function of emission energy.
@@ -566,6 +570,16 @@ def plot_rixs_spectrum(rixs_results,
     ev_x_nm = hartree_in_ev() / hartree_in_inverse_nm()
     au2ev = hartree_in_ev()
 
+    incoming_ev = np.asarray(rixs_results['elastic_emission']) * au2ev
+
+    if photon_energy is not None:
+        photon_index = int(np.argmin(np.abs(incoming_ev - photon_energy)))
+
+    assert_msg_critical(
+        photon_index >= 0 and photon_index < incoming_ev.size,
+        'plot: photon_index out of range.'
+    )
+
     if ax is None:
         fig, ax = plt.subplots(figsize=(8, 5))
 
@@ -580,18 +594,10 @@ def plot_rixs_spectrum(rixs_results,
         else:
             ax.set_xlabel('Emission energy [nm]')
 
+    omega_ev = incoming_ev[photon_index]
+
     ax.set_ylabel(r'Reduced cross section, $\sigma/r_e^2$')
-    ax.set_title("RIXS Spectrum")
-
-    omega_ev = rixs_results['elastic_emission'][photon_index] * au2ev
-
-    ax.text(
-        0.03, 0.95,
-        rf'$\hbar \omega = {omega_ev:.2f}$ eV',
-        transform=ax.transAxes,
-        ha='left',
-        va='top'
-    )
+    ax.set_title(rf"RIXS Spectrum @ $\hbar \omega = {omega_ev:.2f}$ eV")
 
     if energy_loss:
         x = rixs_results['energy_losses'][:, photon_index]
@@ -671,10 +677,10 @@ def plot_rixs_spectrum(rixs_results,
                                     label=label_spectrum)
 
     ax2.legend(handles=[legend_bars, legend_spectrum],
-            frameon=False,
-            borderaxespad=0.,
-            loc='center left',
-            bbox_to_anchor=(1.15, 0.5))
+               frameon=False,
+               borderaxespad=0.,
+               loc='center left',
+               bbox_to_anchor=(1.15, 0.5))
 
     ax.set_ylim(0, max(abs(y)) * 1.1)
     ax.set_ylim(bottom=0)
@@ -693,6 +699,435 @@ def plot_rixs_spectrum(rixs_results,
     ax.set_xlim(x_lim)
     ax2.set_xlim(x_lim)
 
+    return ax
+
+def plot_rixs_slices(rixs_results,
+                     photon_indices,
+                     energy_loss=True,
+                     broadening_type="lorentzian",
+                     broadening_value=0.24,
+                     x_step=0.01,
+                     x_unit="ev",
+                     normalize=True,
+                     ax=None):
+    """
+    Plot several RIXS spectra as stacked 1D slices.
+
+    :param rixs_results:
+        The dictionary containing the RIXS results.
+    :param photon_indices:
+        List of incoming photon indices to plot.
+    :param energy_loss:
+        If True, plot as a function of energy loss.
+        If False, plot as a function of emission energy.
+    :param broadening_type:
+        The type of broadening to use. Either 'lorentzian' or 'gaussian'.
+    :param broadening_value:
+        The FWHM in eV.
+    :param x_step:
+        Grid spacing in eV for the broadened spectra.
+    :param x_unit:
+        Only 'ev' is supported.
+    :param normalize:
+        If True, normalize all broadened spectra by the global maximum.
+    :param ax:
+        The matplotlib axis to plot on.
+    """
+
+    assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
+    assert_msg_critical(x_unit.lower() == 'ev',
+                        'plot_rixs_slices: only x_unit="ev" is currently supported.')
+
+    au2ev = hartree_in_ev()
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(8, 6))
+
+    photon_indices = np.asarray(photon_indices, dtype=int)
+
+    incoming_ev = np.asarray(rixs_results['elastic_emission']) * au2ev
+    cross_sections = np.asarray(rixs_results['cross_sections'])
+
+    if energy_loss:
+        x_au = np.asarray(rixs_results['energy_losses'])
+        ax.set_xlabel('Energy loss [eV]')
+    else:
+        x_au = np.asarray(rixs_results['emission_energies'])
+        ax.set_xlabel('Emission energy [eV]')
+
+    x_ev = x_au * au2ev
+
+    assert_msg_critical(
+        x_ev.shape == cross_sections.shape,
+        'plot_rixs_slices: x values and cross sections have incompatible shapes.'
+    )
+
+    assert_msg_critical(
+        np.all(photon_indices >= 0) and np.all(photon_indices < incoming_ev.size),
+        'plot_rixs_slices: photon_index out of range.'
+    )
+
+    sort_idx = np.argsort(incoming_ev[photon_indices])
+    photon_indices = photon_indices[sort_idx]
+
+    x_sel = x_ev[:, photon_indices]
+    y_sel = cross_sections[:, photon_indices]
+    incoming_sel_ev = incoming_ev[photon_indices]
+
+    x_sel = x_ev[:, photon_indices]
+    y_sel = cross_sections[:, photon_indices]
+    incoming_sel_ev = incoming_ev[photon_indices]
+
+    # pad x-range to ensure broadened spectra are not cut off at the edges
+    x_pad = max(0.25, 2.0 * broadening_value)
+
+    xmin_ev = np.min(x_sel) - x_pad
+    xmax_ev = np.max(x_sel) + x_pad
+
+    if energy_loss:
+        xmin_ev = max(0.0, xmin_ev)
+
+    spectra = []
+    xi = None
+
+    for col in range(len(photon_indices)):
+
+        if broadening_type.lower() == "lorentzian":
+            xi_tmp, yi_tmp = lorentzian_xps(
+                x_sel[:, col],
+                y_sel[:, col],
+                xmin_ev,
+                xmax_ev,
+                x_step,
+                broadening_value
+            )
+
+        elif broadening_type.lower() == "gaussian":
+            xi_tmp, yi_tmp = gaussian_xps(
+                x_sel[:, col],
+                y_sel[:, col],
+                xmin_ev,
+                xmax_ev,
+                x_step,
+                broadening_value
+            )
+
+        else:
+            assert_msg_critical(False, 'plot_rixs_slices: Invalid broadening_type')
+
+        if xi is None:
+            xi = xi_tmp
+
+        spectra.append(yi_tmp)
+
+    spectra = np.asarray(spectra)
+
+    # normalize all spectra by the global maximum if requested
+    if normalize:
+        max_intensity = np.max(np.abs(spectra))
+
+        if max_intensity > 0.0:
+            spectra = spectra / max_intensity
+    else:
+        max_intensity = 1.0
+
+    stick_heights = np.array(y_sel, copy=True)
+
+    if normalize:
+        max_stick = np.max(np.abs(stick_heights))
+
+        if max_stick > 0.0:
+            stick_heights = stick_heights / max_stick
+
+    offset = 1.2
+
+    for i, omega_ev in enumerate(incoming_sel_ev):
+        y_offset = i * offset
+
+        for k in range(x_sel.shape[0]):
+            ax.plot(
+                [x_sel[k, i], x_sel[k, i]],
+                [y_offset, y_offset + stick_heights[k, i]],
+                alpha=0.7,
+                linewidth=2,
+                color="darkcyan",
+            )
+
+        ax.plot(
+            xi,
+            spectra[i] + y_offset,
+            color='black',
+            linewidth=2.0
+        )
+
+    if energy_loss:
+        ax.set_xlim(xi.max(), xi.min())
+    else:
+        ax.set_xlim(xi.min(), xi.max())
+
+    ax.set_ylabel('Incoming photon energy [eV]')
+    ax.set_yticks(np.arange(len(incoming_sel_ev)) * offset)
+    ax.set_yticklabels([f'{omega:.2f}' for omega in incoming_sel_ev])
+
+    label_spectrum = f'{broadening_type.capitalize()} '
+    label_spectrum += f'broadening ({broadening_value:.3f} eV)'
+    title_spectrum = 'RIXS Spectra'
+
+    ax.set_title(title_spectrum)
+
+    ax.tick_params(axis='both', which='both',
+                   direction='out',
+                   bottom=True, top=False,
+                   left=True, right=False,
+                   labelbottom=True, labeltop=False,
+                   labelleft=True, labelright=False)
+
+    legend_bars = mlines.Line2D([], [],
+                                color='darkcyan',
+                                alpha=0.7,
+                                linewidth=2,
+                                label='Cross section')
+
+    legend_spectrum = mlines.Line2D([], [],
+                                    color='black',
+                                    linestyle='-',
+                                    linewidth=2.5,
+                                    label=label_spectrum)
+
+    ax.legend(handles=[legend_bars, legend_spectrum],
+              frameon=False,
+              borderaxespad=0.,
+              loc='center left',
+              bbox_to_anchor=(1.05, 0.5))
+
+    return ax
+
+def plot_rixs_map(rixs_results,
+                  energy_loss=True,
+                  broadening_type="lorentzian",
+                  broadening_value=0.24,
+                  x_step=0.01,
+                  x_unit="ev",
+                  cmap='viridis',
+                  ax=None):
+    """
+    Plot a 2D RIXS map together with the corresponding XAS.
+
+    :param rixs_results:
+        The dictionary containing the RIXS results.
+    :param energy_loss:
+        If True, plot the map as a function of energy loss. (RIXS)
+        If False, plot the map as a function of emission energy. (res-XES)
+    :param broadening_type:
+        The type of broadening to use. Either 'lorentzian' or 'gaussian'.
+    :param broadening_value:
+        The FWHM in eV.
+    :param x_step:
+        Grid spacing in eV for the broadened RIXS map.
+    :param x_unit:
+        Only 'ev' is supported.
+    :param ax:
+        If None, create new axes.
+        Otherwise pass a tuple (ax_map, ax_xas).
+
+    :return:
+        (ax_map, ax_xas)
+    """
+
+    assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
+    assert_msg_critical(x_unit.lower() == 'ev',
+                        'plot_rixs_map: only x_unit="ev" is currently supported.')
+
+    au2ev = hartree_in_ev()
+
+    if ax is None:
+        fig, (ax_map, ax_xas) = plt.subplots(
+            1, 2,
+            sharey=True,
+            figsize=(10, 6),
+            gridspec_kw={'wspace': 0.00, 'width_ratios': [4, 1.25]}
+        )
+    else:
+        ax_map, ax_xas = ax
+        fig = ax_map.figure
+
+    incoming_ev = np.array(rixs_results['elastic_emission']) * au2ev
+    core_eigvals_ev = np.array(rixs_results['core_eigenvalues']) * au2ev
+    gamma_fwhm_ev = float(rixs_results['gamma_fwhm_ev'])
+    core_osc_strs = np.array(rixs_results['core_osc_strengths'])
+    cross_sections = np.array(rixs_results['cross_sections'])
+
+    if energy_loss:
+        x_au = np.array(rixs_results['energy_losses'])
+    else:
+        x_au = np.array(rixs_results['emission_energies'])
+
+    x_ev = x_au * au2ev
+
+    assert_msg_critical(
+        core_eigvals_ev.size == core_osc_strs.size,
+        'plot_rixs_map: number of core eigenvalues does not match oscillator strengths.'
+    )
+
+    sort_idx = np.argsort(incoming_ev)
+    incoming_ev = incoming_ev[sort_idx]
+    x_ev = x_ev[:, sort_idx]
+    cross_sections = cross_sections[:, sort_idx]
+
+    xas_sort_idx = np.argsort(core_eigvals_ev)
+    core_eigvals_ev = core_eigvals_ev[xas_sort_idx]
+    core_osc_strs = core_osc_strs[xas_sort_idx]
+
+    xmin_ev = np.min(x_ev)
+    xmax_ev = np.max(x_ev)
+
+    pad = 0.5
+    if energy_loss:
+        val_min_ev = max(0.0, xmin_ev - pad)
+        val_max_ev = xmax_ev + pad
+    else:
+        val_min_ev = xmin_ev - pad
+        val_max_ev = xmax_ev + pad
+
+    n_photons = incoming_ev.size
+
+    xi = None
+    rixs_map = None
+
+    for i in range(n_photons):
+
+        if broadening_type.lower() == "lorentzian":
+            xi_tmp, yi_tmp = lorentzian_xps(
+                x_ev[:, i],
+                cross_sections[:, i],
+                val_min_ev,
+                val_max_ev,
+                x_step,
+                broadening_value
+            )
+
+        elif broadening_type.lower() == "gaussian":
+            xi_tmp, yi_tmp = gaussian_xps(
+                x_ev[:, i],
+                cross_sections[:, i],
+                val_min_ev,
+                val_max_ev,
+                x_step,
+                broadening_value
+            )
+
+        else:
+            assert_msg_critical(False, 'plot_rixs_map: Invalid broadening_type')
+
+        if xi is None:
+            xi = xi_tmp
+            rixs_map = np.zeros((len(xi), n_photons))
+
+        assert_msg_critical(
+            len(xi_tmp) == len(xi),
+            'plot_rixs_map: inconsistent broadening grids between photon energies.'
+        )
+
+        rixs_map[:, i] = yi_tmp
+
+    # rows = incoming photon energies, cols = loss/emission
+    Z = rixs_map.T
+
+    ymin_map = incoming_ev.min()
+    ymax_map = incoming_ev.max()
+
+    limits = [xi.min(), xi.max(), ymin_map, ymax_map]
+
+    im = ax_map.imshow(
+        Z,
+        extent=limits,
+        origin='lower',
+        aspect='auto',
+        cmap=cmap
+    )
+
+    xas_pos = ax_xas.get_position()
+
+    cbar_pad = 0.012
+    cbar_width = 0.020
+
+    cax = fig.add_axes([
+        xas_pos.x1 + cbar_pad,
+        xas_pos.y0,
+        cbar_width,
+        xas_pos.height
+    ])
+
+    cbar = fig.colorbar(im, cax=cax)
+    cbar.set_label(
+        r'Cross section, $d / d\omega (\sigma/r_e^2)$ [eV$^{-1}$]'
+    )
+
+    if energy_loss:
+        ax_map.set_xlabel('Energy loss [eV]')
+    else:
+        ax_map.set_xlabel('Emission energy [eV]')
+
+    ax_map.set_ylabel('Photon energy [eV]')
+    ax_map.set_title('RIXS map')
+
+    # reverse x-axis for energy-loss convention
+    if energy_loss:
+        ax_map.set_xlim(xi.max(), xi.min())
+    else:
+        ax_map.set_xlim(xi.min(), xi.max())
+
+    xas_min_ev = core_eigvals_ev.min() - 1.0
+    xas_max_ev = core_eigvals_ev.max() + 1.0
+
+    if broadening_type.lower() == "lorentzian":
+        xas_x, xas_y = lorentzian_xps(
+            core_eigvals_ev,
+            core_osc_strs,
+            xas_min_ev,
+            xas_max_ev,
+            0.01,
+            gamma_fwhm_ev
+        )
+
+    elif broadening_type.lower() == "gaussian":
+        xas_x, xas_y = gaussian_xps(
+            core_eigvals_ev,
+            core_osc_strs,
+            xas_min_ev,
+            xas_max_ev,
+            0.01,
+            gamma_fwhm_ev
+        )
+
+    ax_xas.plot(xas_y, xas_x, lw=2.5, color='black')
+    ax_xas.fill_betweenx(xas_x, 0.0, xas_y, alpha=0.2, color='black')
+    ax_xas.barh(core_eigvals_ev, core_osc_strs, height=0.025, color='darkcyan', alpha=0.7)
+
+    ax_xas.set_title('XAS')
+    ax_xas.set_xlabel('Intensity')
+    ax_xas.yaxis.set_visible(False)
+    ax_xas.set_xlim(left=0.0)
+    ax_xas.set_xticks([])
+
+    ax_map.set_ylim(ymin_map, ymax_map) #- 0.2
+    ax_xas.set_ylim(ymin_map, ymax_map) #+ 0.2
+    ax_map.tick_params(axis='both', which='both',
+                       direction='out',
+                       bottom=True, top=False,
+                       left=True, right=False,
+                       labelbottom=True, labeltop=False,
+                       labelleft=True, labelright=False)
+
+    ax_xas.tick_params(axis='both', which='both',
+                       direction='out',
+                       bottom=True, top=False,
+                       left=False, right=False,
+                       labelbottom=False, labeltop=False,
+                       labelleft=False, labelright=False)
+    
+
+    return ax_map, ax_xas
 
 def plot_tpa_transition_spectrum(rsp_results,
                                  spectrum,

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -542,6 +542,7 @@ def plot_rixs_spectrum(rixs_results,
                        broadening_value=0.24,
                        x_unit="ev",
                        xstep=0.01,
+                       plot_elastic_line=False,
                        ax=None):
     """
     Plot the RIXS spectrum from a RIXS calculation.
@@ -557,17 +558,18 @@ def plot_rixs_spectrum(rixs_results,
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
         The FWHM in eV.
+    :param x_unit:
+        The unit of x-axis, only 'ev' is enabled.
     :param xstep:
         Grid spacing in eV for the broadened RIXS spectrum.
+    :param plot_elastic_line:
+        If True, include the elastic line in the plot.
     :param ax:
         The matplotlib axis to plot on.
     """
     assert_msg_critical('matplotlib' in sys.modules, 'matplotlib is required.')
-    assert_msg_critical(x_unit.lower() in ['nm', 'ev'], 'plot: Invalid x_unit')
+    assert_msg_critical(x_unit.lower() in ['ev'], 'plot: Invalid x_unit')
 
-    use_ev = (x_unit.lower() == 'ev')
-
-    ev_x_nm = hartree_in_ev() / hartree_in_inverse_nm()
     au2ev = hartree_in_ev()
 
     # incoming photon energies in eV
@@ -582,54 +584,41 @@ def plot_rixs_spectrum(rixs_results,
         fig, ax = plt.subplots(figsize=(8, 5))
 
     if energy_loss:
-        if use_ev:
-            ax.set_xlabel('Energy loss [eV]')
-        else:
-            ax.set_xlabel('Energy loss [nm]')
+        ax.set_xlabel('Energy loss [eV]')
     else:
-        if use_ev:
-            ax.set_xlabel('Emission energy [eV]')
-        else:
-            ax.set_xlabel('Emission energy [nm]')
+        ax.set_xlabel('Emission energy [eV]')
 
     omega_ev = incoming_ev[photon_index]
 
     ax.set_ylabel(r'Normalized intensity [arb. units]')
     ax.set_title(rf"RIXS Spectrum @ $\hbar \omega = {omega_ev:.2f}$ eV")
 
-    if energy_loss:
-        x = rixs_results['energy_losses'][:, photon_index]
-    else:
-        x = rixs_results['emission_energies'][:, photon_index]
+    x_key = 'energy_losses' if energy_loss else 'emission_energies'
 
-    y = rixs_results['cross_sections'][:, photon_index]
+    x = np.asarray(rixs_results[x_key])[:, photon_index]
+    y = np.asarray(rixs_results['cross_sections'])[:, photon_index]
 
-    x_ev = np.asarray(x)
+    if plot_elastic_line:
+        x0 = 0.0 if energy_loss else rixs_results['photon_energies'][photon_index]
+        y0 = rixs_results['elastic_cross_sections'][photon_index]
 
-    pad_ev = 0.03
-    xmin_ev = max(0.0, np.min(x_ev) - pad_ev)
+        x = np.insert(x, 0, x0)
+        y = np.insert(y, 0, y0)
+
+    x_ev = x * au2ev
+
+    pad_ev = 1.25
+    xmin_ev = np.min(x_ev) - pad_ev
     xmax_ev = np.max(x_ev) + pad_ev
     xstep = xstep
 
     ax2 = ax.twinx()
     ax2.set_ylabel(r'Cross section, $\sigma$ [a.u.]')
 
-    for i in np.arange(len(y)):
-        if energy_loss:
-            energy_au = rixs_results['energy_losses'][i, photon_index]
-        else:
-            energy_au = rixs_results['emission_energies'][i, photon_index]
-
-        energy_ev = energy_au * au2ev
-
-        if use_ev:
-            x_val = energy_ev
-        else:
-            x_val = ev_x_nm / energy_ev
-
+    for x_val, y_val in zip(x_ev, y):
         ax2.plot(
             [x_val, x_val],
-            [0.0, rixs_results['cross_sections'][i, photon_index]],
+            [0.0, y_val],
             alpha=0.7,
             linewidth=2,
             color="darkcyan",
@@ -658,10 +647,7 @@ def plot_rixs_spectrum(rixs_results,
 
     norm_intensity = yi / max_intensity
 
-    if use_ev:
-        x_data = xi
-    else:
-        x_data = ev_x_nm / xi
+    x_data = xi
 
     ax.plot(x_data, norm_intensity, color="black", alpha=0.9, linewidth=2.5)
 
@@ -692,10 +678,7 @@ def plot_rixs_spectrum(rixs_results,
     ax.set_ylim(0, max(norm_intensity) * 1.1)
     ax.set_ylim(bottom=-0.02 * max(abs(norm_intensity)))
 
-    if use_ev:
-        x_lim = (xmin_ev, xmax_ev)
-    else:
-        x_lim = (ev_x_nm / xmax_ev, ev_x_nm / xmin_ev)
+    x_lim = (xmin_ev, xmax_ev)
 
     if energy_loss:
         x_lim = x_lim[::-1]
@@ -714,6 +697,7 @@ def plot_rixs_map(rixs_results,
                   x_unit="ev",
                   cmap='viridis',
                   normalize='global_max',
+                  plot_elastic_line=False,
                   ax=None):
     """
     Plot a 2D RIXS map together with the corresponding XAS.
@@ -775,9 +759,21 @@ def plot_rixs_map(rixs_results,
     )
 
     sort_idx = np.argsort(incoming_photon_energies_ev)
+
     incoming_photon_energies_ev = incoming_photon_energies_ev[sort_idx]
     x_ev = x_ev[:, sort_idx]
     cross_sections = cross_sections[:, sort_idx]
+
+    if plot_elastic_line:
+        elastic_cross_sections = np.array(rixs_results['elastic_cross_sections'])[sort_idx]
+
+        if energy_loss:
+            elastic_x_ev = np.zeros_like(incoming_photon_energies_ev)
+        else:
+            elastic_x_ev = incoming_photon_energies_ev.copy()
+
+        x_ev = np.vstack((elastic_x_ev, x_ev))
+        cross_sections = np.vstack((elastic_cross_sections, cross_sections))
 
     xas_sort_idx = np.argsort(core_eigvals_ev)
     core_eigvals_ev = core_eigvals_ev[xas_sort_idx]
@@ -788,7 +784,7 @@ def plot_rixs_map(rixs_results,
 
     pad = 0.5
     if energy_loss:
-        val_min_ev = max(0.0, xmin_ev - pad)
+        val_min_ev = xmin_ev - pad
         val_max_ev = xmax_ev + pad
     else:
         val_min_ev = xmin_ev - pad

--- a/src/pymodule/spectrumplot.py
+++ b/src/pymodule/spectrumplot.py
@@ -541,7 +541,7 @@ def plot_rixs_spectrum(rixs_results,
                        broadening_type="lorentzian",
                        broadening_value=0.24,
                        x_unit="ev",
-                       x_step=0.01,
+                       xstep=0.01,
                        ax=None):
     """
     Plot the RIXS spectrum from a RIXS calculation.
@@ -557,7 +557,7 @@ def plot_rixs_spectrum(rixs_results,
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
         The FWHM in eV.
-    :param x_step:
+    :param xstep:
         Grid spacing in eV for the broadened RIXS spectrum.
     :param ax:
         The matplotlib axis to plot on.
@@ -604,14 +604,12 @@ def plot_rixs_spectrum(rixs_results,
 
     y = rixs_results['cross_sections'][:, photon_index]
 
-    xmin = max(0.0, min(x) - 0.03)
-    xmax = max(x) + 0.03
-    xstep = x_step
+    x_ev = np.asarray(x)
 
-    x_ev = x * au2ev
-    xmin_ev = xmin * au2ev
-    xmax_ev = xmax * au2ev
-    xstep_ev = xstep * au2ev
+    pad_ev = 0.03
+    xmin_ev = max(0.0, np.min(x_ev) - pad_ev)
+    xmax_ev = np.max(x_ev) + pad_ev
+    xstep = xstep
 
     ax2 = ax.twinx()
     ax2.set_ylabel(r'Cross section, $\sigma$ [a.u.]')
@@ -639,12 +637,12 @@ def plot_rixs_spectrum(rixs_results,
 
     if broadening_type.lower() == "lorentzian":
         xi, yi = lorentzian_xps(
-            x_ev, y, xmin_ev, xmax_ev, xstep_ev, broadening_value
+            x_ev, y, xmin_ev, xmax_ev, xstep, broadening_value
         )
 
     elif broadening_type.lower() == "gaussian":
         xi, yi = gaussian_xps(
-            x_ev, y, xmin_ev, xmax_ev, xstep_ev, broadening_value
+            x_ev, y, xmin_ev, xmax_ev, xstep, broadening_value
         )
 
     else:
@@ -712,7 +710,7 @@ def plot_rixs_map(rixs_results,
                   energy_loss=True,
                   broadening_type="lorentzian",
                   broadening_value=0.24,
-                  x_step=0.01,
+                  xstep=0.01,
                   x_unit="ev",
                   cmap='viridis',
                   normalize='global_max',
@@ -729,7 +727,7 @@ def plot_rixs_map(rixs_results,
         The type of broadening to use. Either 'lorentzian' or 'gaussian'.
     :param broadening_value:
         The FWHM in eV.
-    :param x_step:
+    :param xstep:
         Grid spacing in eV for the broadened RIXS map.
     :param x_unit:
         Only 'ev' is supported.
@@ -798,6 +796,14 @@ def plot_rixs_map(rixs_results,
 
     nr_incoming_photons = incoming_photon_energies_ev.size
 
+    photon_diffs_ev = np.diff(incoming_photon_energies_ev)
+    photon_step_ev = photon_diffs_ev[0]
+
+    assert_msg_critical(
+        np.allclose(photon_diffs_ev, photon_step_ev, rtol=1.0e-5, atol=1.0e-8),
+        'plot_rixs_map: imshow requires uniformly spaced incoming photon energies. '
+    )
+
     xi = None
     rixs_map = None
 
@@ -809,7 +815,7 @@ def plot_rixs_map(rixs_results,
                 cross_sections[:, i],
                 val_min_ev,
                 val_max_ev,
-                x_step,
+                xstep,
                 broadening_value
             )
 
@@ -819,7 +825,7 @@ def plot_rixs_map(rixs_results,
                 cross_sections[:, i],
                 val_min_ev,
                 val_max_ev,
-                x_step,
+                xstep,
                 broadening_value
             )
 
@@ -859,8 +865,8 @@ def plot_rixs_map(rixs_results,
                 'plot_rixs_map: Invalid normalize option. Use None or "global_max".'
             )
 
-    ymin_map = incoming_photon_energies_ev.min()
-    ymax_map = incoming_photon_energies_ev.max()
+    ymin_map = incoming_photon_energies_ev.min() - 0.5 * photon_step_ev
+    ymax_map = incoming_photon_energies_ev.max() + 0.5 * photon_step_ev
 
     limits = [xi.min(), xi.max(), ymin_map, ymax_map]
 

--- a/tests/data/water_rixs_scf.inp
+++ b/tests/data/water_rixs_scf.inp
@@ -1,0 +1,16 @@
+@jobs
+task: scf
+@end
+
+@method settings
+basis: def2-svpd 
+@end
+
+@molecule
+charge: 0
+multiplicity: 1
+xyz:  
+O          -0.047424118711       -0.000000000360       -0.033716003849
+H           0.034041961427        0.000000000693        0.952334284820
+H           0.909380965625       -0.000000000444       -0.285619983969
+@end 

--- a/tests/test_resultsio.py
+++ b/tests/test_resultsio.py
@@ -12,6 +12,7 @@ from veloxchem.cppsolver import ComplexResponseSolver
 from veloxchem.lreigensolver import LinearResponseEigenSolver
 from veloxchem.resultsio import (read_results, write_results_to_hdf5,
                                  write_scf_results_to_hdf5)
+from veloxchem.rixsdriver import RixsDriver
 from veloxchem.tdaeigensolver import TdaEigenSolver
 from veloxchem.vibrationalanalysis import VibrationalAnalysis
 
@@ -589,3 +590,35 @@ def test_vib_results_hdf5_roundtrip_with_water_calculation(tmp_path):
         _assert_roundtrip_equal(vib_results, recovered)
         assert 'basis_set' not in recovered
         assert 'nuclear_charges' not in recovered
+
+def test_rixs_results_hdf5_roundtrip_with_water_calculation(tmp_path):
+    here = Path(__file__).parent
+    inpfile = str(here / 'data' / 'water_rixs_scf.inp')
+
+    task = MpiTask([inpfile, None])
+    filename = str(tmp_path / 'water_rixs_results')
+    filename = task.mpi_comm.bcast(filename, root=mpi_master())
+
+    scf_drv = ScfRestrictedDriver(task.mpi_comm, task.ostream)
+    scf_drv.filename = filename
+    scf_results = scf_drv.compute(task.molecule, task.ao_basis)
+
+    rixs_drv = RixsDriver()
+    rixs_drv.update_settings({
+        'num_core_orbitals': 1,
+        'num_core_states': 5,
+        'photon_energy': '20.17505501',
+        'nstates': 15,
+        'gamma': 0.00587,
+        'theta': 0,
+        'filename': filename,
+    }, {})
+    rixs_drv.ostream.mute()
+    rixs_results = rixs_drv.compute(task.molecule, task.ao_basis, scf_results)
+
+    if task.mpi_rank == mpi_master():
+        recovered = read_results(f'{filename}.h5', 'rixs')
+        _assert_roundtrip_equal(rixs_results, recovered)
+        assert 'basis_set' not in recovered
+        assert 'nuclear_charges' not in recovered
+

--- a/tests/test_rixs.py
+++ b/tests/test_rixs.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from veloxchem.veloxchemlib import mpi_master, hartree_in_ev
+from veloxchem.veloxchemlib import mpi_master, hartree_in_ev, fine_structure_constant
 from veloxchem.molecule import Molecule
 from veloxchem.molecularbasis import MolecularBasis
 from veloxchem.scfrestdriver import ScfRestrictedDriver
@@ -53,6 +53,7 @@ class TestRIXS:
         rixs_res = rixs_drv.compute(mol, bas, scf_results)
 
         if scf_drv.rank == mpi_master():
+            ref_xsection = np.array(ref_xsection) * fine_structure_constant()**4
             assert np.allclose(ref_xsection, rixs_res['cross_sections'][:,0], 
                                rtol=1e-5, atol=1e-8)
 

--- a/tests/test_rixs_misc.py
+++ b/tests/test_rixs_misc.py
@@ -31,24 +31,9 @@ class TestRixsDriverUtilities:
 
         driver = RixsDriver()
 
-        driver.update_settings({'photon_energy': '1.25, 2.50 3.75'})
+        driver.update_settings({'photon_energy': '1.25, 2.50, 3.75'})
 
         assert driver.photon_energy == pytest.approx([1.25, 2.50, 3.75])
-
-    @pytest.mark.skipif(MPI.COMM_WORLD.Get_size() > 1,
-                        reason='skip pytest.raises for multiple MPI processes')
-    @pytest.mark.parametrize('rsp_dict', [
-        {'photon_energy': ''},
-        {'photon_energy': '   '},
-        {'photon_energy': []},
-        {'photon_energy': ()},
-    ])
-    def test_update_settings_rejects_empty_photon_energy_input(self, rsp_dict):
-
-        driver = RixsDriver()
-
-        with pytest.raises(ValueError, match='photon_energy'):
-            driver.update_settings(rsp_dict)
 
     def test_print_info_warns_when_no_results_available(self):
 
@@ -84,53 +69,3 @@ class TestRixsDriverUtilities:
             'MO indices (core, valence, virtual): ([0], [4, 5], [6, 7])',
             'State indices (intermediate, final): ([0, 2], [1, 3, 4])',
         ]
-
-    @pytest.mark.skipif(MPI.COMM_WORLD.Get_size() > 1,
-                        reason='skip file I/O for multiple MPI processes')
-    def test_write_hdf5_accepts_path_objects_and_appends_extension(self,
-                                                                   tmp_path):
-
-        driver = RixsDriver()
-        driver.photon_energy = [1.0]
-        driver.cross_sections = np.array([[2.0]])
-        driver.emission_enes = np.array([[3.0]])
-        driver.ene_losses = np.array([[4.0]])
-        driver.elastic_cross_sections = np.array([5.0])
-        driver.scattering_amplitudes = np.array([[[[6.0 + 0.0j]]]])
-
-        target = tmp_path / 'rixs_results'
-        driver._write_hdf5(target)
-
-        assert target.with_suffix('.h5').is_file()
-
-    @pytest.mark.skipif(MPI.COMM_WORLD.Get_size() > 1,
-                        reason='skip file I/O for multiple MPI processes')
-    def test_write_hdf5_overwrites_existing_rixs_datasets(self, tmp_path):
-
-        driver = RixsDriver()
-        driver.photon_energy = [1.0]
-        driver.cross_sections = np.array([[2.0]])
-        driver.emission_enes = np.array([[3.0]])
-        driver.ene_losses = np.array([[4.0]])
-        driver.elastic_cross_sections = np.array([5.0])
-        driver.scattering_amplitudes = np.array([[[[6.0 + 0.0j]]]])
-
-        target = tmp_path / 'shared_results.h5'
-        driver._write_hdf5(target)
-
-        driver.photon_energy = [7.0]
-        driver.cross_sections = np.array([[8.0]])
-        driver.emission_enes = np.array([[9.0]])
-        driver.ene_losses = np.array([[10.0]])
-        driver.elastic_cross_sections = np.array([11.0])
-        driver.scattering_amplitudes = np.array([[[[12.0 + 0.0j]]]])
-        driver._write_hdf5(target)
-
-        with h5py.File(target, 'r') as h5f:
-            assert h5f['rixs/photon_energies'][()] == pytest.approx([7.0])
-            assert np.allclose(h5f['rixs/cross_sections'][()], [[8.0]])
-            assert np.allclose(h5f['rixs/emission_energies'][()], [[9.0]])
-            assert np.allclose(h5f['rixs/energy_losses'][()], [[10.0]])
-            assert h5f['rixs/elastic_cross_sections'][()] == pytest.approx([11.0])
-            assert np.allclose(h5f['rixs/scattering_amplitudes'][()],
-                               [[[[12.0 + 0.0j]]]])


### PR DESCRIPTION
## **UPDATED**

This PR adds plotting functionality to `RixsDriver` and enables writing and reading RIXS results to HDF5 files through the `resultsio` module. In addition, a few issues are fixed:
- missing fine structure constant added to get the RIXS scattering cross-section in a.u.,
- set `photon_energy` instance variable as a `seq_range` so it can be handled directly by  parent class `update_settings`,
- skip check `is_converged` for RIXS calculations in main, since convergence does not apply to the `RixsDriver`.

### Notebook example of using `RixsDriver` plotting functionality:

```
import veloxchem as vlx
import numpy as np

import numpy as np

xyz = """3

O    0.000000000000        0.000000000000        0.000000000000
H    0.000000000000        0.740848095288        0.582094932012
H    0.000000000000       -0.740848095288        0.582094932012
"""

molecule = vlx.Molecule.read_xyz_string(xyz)
basis = vlx.MolecularBasis.read(molecule, 'def2-svpd')

scf_drv = vlx.ScfRestrictedDriver()
scf_results = scf_drv.compute(molecule, basis)

rixs_drv = vlx.RixsDriver()
rixs_drv.num_core_orbitals = 1
rixs_drv.num_core_states = 5
rixs_drv.photon_energy = np.linspace(551.0 / vlx.hartree_in_ev(), 557.5 / vlx.hartree_in_ev(), 100)
rixs_drv.nstates = 15

rixs_results = rixs_drv.compute(molecule, basis, scf_results)

rixs_drv.plot_map(rixs_results)
```

<img width="752" height="436" alt="image" src="https://github.com/user-attachments/assets/792c956f-9753-4fe8-977e-1556c4c31cc2" />

```
rixs_drv.plot(rixs_results, photon_energy_ev=552.5)
```

<img width="859" height="372" alt="image" src="https://github.com/user-attachments/assets/efd6174f-f762-48d9-82ff-e7cb5fdbbb5f" />


### Notbook example reading RIXS results from an HDF5 file ([esca_rixs.h5](https://drive.google.com/file/d/1zA6iuun8UtzxO4CLT4IALHVUIrmRpB98/view?usp=sharing), [esca_rixs.inp](https://drive.google.com/file/d/1EQlSHXdvAeC8l0udZ4zliTK4dlTOYNYx/view?usp=sharing) )
```
import veloxchem as vlx

molecule, basis = vlx.read_molecule_and_basis("esca_rixs.h5")
rixs_results = vlx.read_results("esca_rixs.h5", label="rixs")

rixs_drv = vlx.RixsDriver()

rixs_drv.plot_map(rixs_results)
```

<img width="836" height="485" alt="image" src="https://github.com/user-attachments/assets/7e7471c7-0802-4033-ae30-079330c57848" />

```
rixs_drv.plot(rixs_results, photon_energy_ev=278)
```

<img width="952" height="416" alt="image" src="https://github.com/user-attachments/assets/e824886f-2e53-4077-b9b0-4fee169156be" />


**OLD PR description**
This adds plotting functionality for `RixsDriver` through two methods: `plot` and `plot_map`. The plot function plots either a single spectrum at one incoming photon frequency or several spectra. The `plot_map` function plots a RIXS map together with the corresponding XAS spectrum.

Some references used for the RIXS implementation were also added and are now printed when computing RIXS.

Here is an example notebook showing how to use these functions and the available options.

[rixs-plot.ipynb](https://github.com/user-attachments/files/28817440/rixs-plot.ipynb)

An example map obtained with: 
`ax_map, ax = rixs_drv.plot_map(rixs_res, broadening_value_ev=0.24, energy_loss=True, colormap='turbo')`

<img width="2769" height="1634" alt="rixs_map" src="https://github.com/user-attachments/assets/6fce1f99-8ac3-4489-9faa-ee5a93cdd93d" />

